### PR TITLE
Implement splash and onboarding with first-launch logic

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/onboarding/OnboardingFragment.kt
@@ -1,6 +1,23 @@
 package com.besosn.app.presentation.ui.onboarding
 
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
+import com.besosn.app.utils.Constants
 
-class OnboardingFragment : Fragment(R.layout.fragment_onboarding)
+class OnboardingFragment : Fragment(R.layout.fragment_onboarding) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<Button>(R.id.btnStart).setOnClickListener {
+            val prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
+            prefs.edit().putBoolean(Constants.PREF_HAS_SEEN_ONBOARDING, true).apply()
+            findNavController().navigate(R.id.action_onboardingFragment_to_homeFragment)
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/splash/SplashFragment.kt
@@ -1,6 +1,51 @@
 package com.besosn.app.presentation.ui.splash
 
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.animation.AnimationUtils
+import android.widget.ImageView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
+import com.besosn.app.utils.Constants
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-class SplashFragment : Fragment(R.layout.fragment_splash)
+class SplashFragment : Fragment(R.layout.fragment_splash) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val dots = listOf(
+            R.id.dot0,
+            R.id.dot1,
+            R.id.dot2,
+            R.id.dot3
+        )
+
+        val anims = listOf(
+            R.anim.dot_pulse_0,
+            R.anim.dot_pulse_1,
+            R.anim.dot_pulse_2,
+            R.anim.dot_pulse_3
+        )
+
+        dots.zip(anims).forEach { (dotId, animId) ->
+            view.findViewById<ImageView>(dotId)
+                .startAnimation(AnimationUtils.loadAnimation(requireContext(), animId))
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(2500)
+            val prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
+            val hasSeenOnboarding = prefs.getBoolean(Constants.PREF_HAS_SEEN_ONBOARDING, false)
+            if (hasSeenOnboarding) {
+                findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
+            } else {
+                findNavController().navigate(R.id.action_splashFragment_to_onboardingFragment)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/utils/Constants.kt
+++ b/app/src/main/java/com/besosn/app/utils/Constants.kt
@@ -2,5 +2,9 @@ package com.besosn.app.utils
 
 object Constants {
     const val DATABASE_NAME = "app_db"
+
+    // SharedPreferences
+    const val PREFS_NAME = "besosn_prefs"
+    const val PREF_HAS_SEEN_ONBOARDING = "has_seen_onboarding"
 }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,8 +8,8 @@
     tools:context="com.besosn.app.presentation.ui.main.MainActivity">
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container_view"
-        android:name="com.besosn.app.presentation.ui.matches.MatchEditFragment"
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"

--- a/app/src/main/res/layout/fragment_onboarding.xml
+++ b/app/src/main/res/layout/fragment_onboarding.xml
@@ -30,34 +30,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/title_top"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/unbounded"
-                android:gravity="center"
-                android:text="WELCOME TO"
-                android:textColor="@android:color/white"
-                android:textSize="28sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/title_bottom"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/unbounded"
-                android:gravity="start"
-                android:text="BESOSN"
-                android:textColor="@android:color/white"
-                android:textSize="28sp"
-                android:textStyle="bold" />
-        </LinearLayout>
+            android:fontFamily="@font/unbounded"
+            android:gravity="center"
+            android:text="Welcome to Besosn"
+            android:textColor="@android:color/white"
+            android:textSize="28sp"
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/subtitle"
@@ -66,7 +48,7 @@
             android:layout_marginTop="12dp"
             android:fontFamily="@font/poppins_regular"
             android:gravity="start"
-            android:text="Your personal helper in soccer teams manager, inventory and matches. Edit your teams and inventory data. Manage your events in soccer."
+            android:text="Your personal helper in soccer teams manager, inventory, and matches. Edit your teams and inventory data. Manage your events in soccer."
             android:textAlignment="viewStart"
             android:textColor="#DCFFFFFF"
             android:textSize="14sp" />

--- a/app/src/main/res/navigation/navgraph.xml
+++ b/app/src/main/res/navigation/navgraph.xml
@@ -1,11 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/navgraph.xml"
-    app:startDestination="@id/inventoryEditFragment">
+    android:id="@+id/navgraph"
+    app:startDestination="@id/splashFragment">
 
     <fragment
-        android:id="@+id/inventoryEditFragment"
-        android:name="com.besosn.app.presentation.ui.inventory.InventoryEditFragment"
-        android:label="InventoryEditFragment" />
+        android:id="@+id/splashFragment"
+        android:name="com.besosn.app.presentation.ui.splash.SplashFragment"
+        android:label="SplashFragment">
+        <action
+            android:id="@+id/action_splashFragment_to_onboardingFragment"
+            app:destination="@id/onboardingFragment" />
+        <action
+            android:id="@+id/action_splashFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/onboardingFragment"
+        android:name="com.besosn.app.presentation.ui.onboarding.OnboardingFragment"
+        android:label="OnboardingFragment">
+        <action
+            android:id="@+id/action_onboardingFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.besosn.app.presentation.ui.home.HomeFragment"
+        android:label="HomeFragment" />
+
 </navigation>
+


### PR DESCRIPTION
## Summary
- add first-launch SharedPreferences constants
- implement SplashFragment with animated dots and navigation to onboarding or home
- wire up OnboardingFragment to store flag and start app
- define nav graph and NavHost layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c788d086a4832a83c48ba429ca4bd2