### PR TITLE
feat: implement teams screen

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayerModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayerModel.kt
@@ -1,0 +1,12 @@
+package com.besosn.app.presentation.ui.teams
+
+import java.io.Serializable
+
+/**
+ * Represents a single player inside a team.
+ */
+data class PlayerModel(
+    val fullName: String,
+    val position: String,
+    val number: Int
+) : Serializable

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamModel.kt
@@ -1,0 +1,20 @@
+package com.besosn.app.presentation.ui.teams
+
+import androidx.annotation.DrawableRes
+import java.io.Serializable
+
+/**
+ * UI model representing a team with all information
+ * displayed on the screen.
+ */
+data class TeamModel(
+    val name: String,
+    val city: String,
+    val foundedYear: Int,
+    val notes: String,
+    val players: List<PlayerModel>,
+    @DrawableRes val iconRes: Int,
+    val isDefault: Boolean = false
+) : Serializable {
+    val playersCount: Int get() = players.size
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsAdapter.kt
@@ -1,0 +1,41 @@
+package com.besosn.app.presentation.ui.teams
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.databinding.TeamsItemBinding
+
+/**
+ * Adapter showing list of teams in [TeamsFragment].
+ */
+class TeamsAdapter(
+    private val items: MutableList<TeamModel>,
+    private val onItemClick: (TeamModel) -> Unit
+) : RecyclerView.Adapter<TeamsAdapter.TeamViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamViewHolder {
+        val binding = TeamsItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TeamViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: TeamViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun addTeam(team: TeamModel) {
+        items.add(team)
+        notifyItemInserted(items.size - 1)
+    }
+
+    inner class TeamViewHolder(private val binding: TeamsItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(team: TeamModel) {
+            binding.tvTeamTitle.text = team.name
+            binding.tvTeamCity.text = "${team.city} \u2022"
+            binding.tvTeamPlayers.text = " ${team.playersCount} players"
+            binding.imgTeamLogo.setImageResource(team.iconRes)
+            binding.root.setOnClickListener { onItemClick(team) }
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
@@ -17,12 +17,31 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentTeamsDetailBinding.bind(view)
 
+        val team = requireArguments().getSerializable("team") as? TeamModel
+
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
             findNavController().navigate(R.id.action_teamsDetailFragment_to_teamsEditFragment)
         }
+
+        team?.let { bindTeam(it) }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun bindTeam(team: TeamModel) {
+        binding.imageView2.setImageResource(team.iconRes)
+        binding.tvTeamName.text = team.name
+        binding.tvCityValue.text = team.city
+        binding.tvFoundedValue.text = team.foundedYear.toString()
+        binding.tvPlayersValue.text = team.playersCount.toString()
+
+        if (team.isDefault) {
+            binding.btnEdit.isEnabled = false
+            binding.btnDelete.isEnabled = false
+            binding.btnDelete.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
@@ -3,7 +3,9 @@ package com.besosn.app.presentation.ui.teams
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentTeamsEditBinding
@@ -18,9 +20,38 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
         _binding = FragmentTeamsEditBinding.bind(view)
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+        binding.btnEdit.setOnClickListener { saveTeam() }
+        binding.btnDelete.visibility = View.GONE // no deletion when creating
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+    }
+
+    private fun saveTeam() {
+        val name = binding.etTeamName.text.toString().trim()
+        val city = binding.etCity.text.toString().trim()
+        val founded = binding.etFoundedYear.text.toString().toIntOrNull() ?: 0
+        val playersCount = binding.etPlayersCount.text.toString().toIntOrNull() ?: 0
+        val notes = binding.etNotes.text.toString().trim()
+
+        val players = if (playersCount > 0) {
+            List(playersCount) { index ->
+                PlayerModel("Player ${index + 1}", "", index + 1)
+            }
+        } else emptyList()
+
+        val team = TeamModel(
+            name = name,
+            city = city,
+            foundedYear = founded,
+            notes = notes,
+            players = players,
+            iconRes = R.drawable.ic_users
+        )
+
+        setFragmentResult("add_team_result", bundleOf("team" to team))
+        findNavController().popBackStack()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsFragment.kt
@@ -3,30 +3,77 @@ package com.besosn.app.presentation.ui.teams
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentTeamsBinding
 
+/**
+ * Screen displaying list of teams. Allows navigating to team details
+ * and adding new teams.
+ */
 class TeamsFragment : Fragment(R.layout.fragment_teams) {
 
     private var _binding: FragmentTeamsBinding? = null
     private val binding get() = _binding!!
 
+    private lateinit var adapter: TeamsAdapter
+    private val teams = mutableListOf<TeamModel>()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentTeamsBinding.bind(view)
+
+        adapter = TeamsAdapter(teams) { team ->
+            val bundle = bundleOf("team" to team)
+            findNavController().navigate(R.id.action_teamsFragment_to_teamsDetailFragment, bundle)
+        }
+        binding.rvTeams.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvTeams.adapter = adapter
+
+        // load default teams
+        teams.addAll(defaultTeams())
+        adapter.notifyDataSetChanged()
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {
             findNavController().navigate(R.id.action_teamsFragment_to_teamsEditFragment)
         }
-        binding.rvTeams.setOnClickListener {
-            findNavController().navigate(R.id.action_teamsFragment_to_teamsDetailFragment)
+
+        // Listen for newly added team from edit screen
+        setFragmentResultListener("add_team_result") { _, bundle ->
+            val team = bundle.getSerializable("team") as? TeamModel ?: return@setFragmentResultListener
+            adapter.addTeam(team)
         }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+    }
+
+    private fun defaultTeams(): List<TeamModel> {
+        val team1 = TeamModel(
+            name = "YoungTeam",
+            city = "New York",
+            foundedYear = 2024,
+            notes = "Default team",
+            players = listOf(PlayerModel("Alex Finch", "FW", 10)),
+            iconRes = R.drawable.ic_users,
+            isDefault = true
+        )
+        val team2 = TeamModel(
+            name = "TalentTeam",
+            city = "Chicago",
+            foundedYear = 2021,
+            notes = "Default team",
+            players = listOf(PlayerModel("Yacob Sunny", "GK", 1)),
+            iconRes = R.drawable.ic_users,
+            isDefault = true
+        )
+        return listOf(team1, team2)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_teams_detail.xml
@@ -93,6 +93,7 @@
             android:paddingTop="100dp">
 
             <TextView
+                android:id="@+id/tvTeamName"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="YOUNG\nTEAM"


### PR DESCRIPTION
## Summary
- define Team and Player UI models
- show default teams and allow adding new teams
- display team details and prevent editing default teams

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c795a6bf60832a842b5d6926293886