### PR TITLE
feat: implement teams screen

### DIFF
--- a/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
@@ -21,7 +21,7 @@ import com.besosn.app.data.local.db.dao.TeamDao
         InventoryEntity::class,
         ArticleEntity::class
     ],
-    version = 1
+    version = 2
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun teamDao(): TeamDao

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
@@ -2,15 +2,17 @@ package com.besosn.app.data.local.db.dao
 
 import androidx.room.*
 import com.besosn.app.data.model.PlayerEntity
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PlayerDao {
     @Query("SELECT * FROM players")
-    fun getPlayers(): Flow<List<PlayerEntity>>
+    suspend fun getPlayers(): List<PlayerEntity>
+
+    @Query("SELECT * FROM players WHERE teamId = :teamId")
+    suspend fun getPlayersForTeam(teamId: Int): List<PlayerEntity>
 
     @Insert
-    suspend fun insertPlayer(player: PlayerEntity)
+    suspend fun insertPlayers(players: List<PlayerEntity>)
 
     @Delete
     suspend fun deletePlayer(player: PlayerEntity)

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/TeamDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/TeamDao.kt
@@ -2,15 +2,13 @@ package com.besosn.app.data.local.db.dao
 
 import androidx.room.*
 import com.besosn.app.data.model.TeamEntity
-import kotlinx.coroutines.flow.Flow
-
 @Dao
 interface TeamDao {
     @Query("SELECT * FROM teams")
-    fun getTeams(): Flow<List<TeamEntity>>
+    suspend fun getTeams(): List<TeamEntity>
 
     @Insert
-    suspend fun insertTeam(team: TeamEntity)
+    suspend fun insertTeam(team: TeamEntity): Long
 
     @Delete
     suspend fun deleteTeam(team: TeamEntity)

--- a/app/src/main/java/com/besosn/app/data/model/PlayerEntity.kt
+++ b/app/src/main/java/com/besosn/app/data/model/PlayerEntity.kt
@@ -7,7 +7,8 @@ import androidx.room.PrimaryKey
 data class PlayerEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val teamId: Int,
-    val name: String,
-    val position: String
+    val fullName: String,
+    val position: String,
+    val number: Int
 )
 

--- a/app/src/main/java/com/besosn/app/data/model/TeamEntity.kt
+++ b/app/src/main/java/com/besosn/app/data/model/TeamEntity.kt
@@ -6,6 +6,11 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "teams")
 data class TeamEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
-    val name: String
+    val name: String,
+    val city: String,
+    val foundedYear: Int,
+    val notes: String,
+    val iconRes: Int,
+    val isDefault: Boolean
 )
 

--- a/app/src/main/java/com/besosn/app/di/AppModule.kt
+++ b/app/src/main/java/com/besosn/app/di/AppModule.kt
@@ -17,6 +17,8 @@ object AppModule {
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
-        Room.databaseBuilder(context, AppDatabase::class.java, "app_db").build()
+        Room.databaseBuilder(context, AppDatabase::class.java, "app_db")
+            .fallbackToDestructiveMigration()
+            .build()
 }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayerModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayerModel.kt
@@ -1,0 +1,12 @@
+package com.besosn.app.presentation.ui.teams
+
+import java.io.Serializable
+
+/**
+ * Represents a single player inside a team.
+ */
+data class PlayerModel(
+    val fullName: String,
+    val position: String,
+    val number: Int
+) : Serializable

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamMappers.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamMappers.kt
@@ -1,0 +1,38 @@
+package com.besosn.app.presentation.ui.teams
+
+import com.besosn.app.data.model.PlayerEntity
+import com.besosn.app.data.model.TeamEntity
+
+fun TeamEntity.toModel(players: List<PlayerEntity>): TeamModel = TeamModel(
+    id = id,
+    name = name,
+    city = city,
+    foundedYear = foundedYear,
+    notes = notes,
+    players = players.map { it.toModel() },
+    iconRes = iconRes,
+    isDefault = isDefault
+)
+
+fun PlayerEntity.toModel(): PlayerModel = PlayerModel(
+    fullName = fullName,
+    position = position,
+    number = number
+)
+
+fun TeamModel.toEntity(): TeamEntity = TeamEntity(
+    id = id,
+    name = name,
+    city = city,
+    foundedYear = foundedYear,
+    notes = notes,
+    iconRes = iconRes,
+    isDefault = isDefault
+)
+
+fun PlayerModel.toEntity(teamId: Int): PlayerEntity = PlayerEntity(
+    teamId = teamId,
+    fullName = fullName,
+    position = position,
+    number = number
+)

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamModel.kt
@@ -1,0 +1,21 @@
+package com.besosn.app.presentation.ui.teams
+
+import androidx.annotation.DrawableRes
+import java.io.Serializable
+
+/**
+ * UI model representing a team with all information
+ * displayed on the screen.
+ */
+data class TeamModel(
+    val id: Int = 0,
+    val name: String,
+    val city: String,
+    val foundedYear: Int,
+    val notes: String,
+    val players: List<PlayerModel>,
+    @DrawableRes val iconRes: Int,
+    val isDefault: Boolean = false
+) : Serializable {
+    val playersCount: Int get() = players.size
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsAdapter.kt
@@ -1,0 +1,41 @@
+package com.besosn.app.presentation.ui.teams
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.databinding.TeamsItemBinding
+
+/**
+ * Adapter showing list of teams in [TeamsFragment].
+ */
+class TeamsAdapter(
+    private val items: MutableList<TeamModel>,
+    private val onItemClick: (TeamModel) -> Unit
+) : RecyclerView.Adapter<TeamsAdapter.TeamViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamViewHolder {
+        val binding = TeamsItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TeamViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: TeamViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun addTeam(team: TeamModel) {
+        items.add(team)
+        notifyItemInserted(items.size - 1)
+    }
+
+    inner class TeamViewHolder(private val binding: TeamsItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(team: TeamModel) {
+            binding.tvTeamTitle.text = team.name
+            binding.tvTeamCity.text = "${team.city} \u2022"
+            binding.tvTeamPlayers.text = " ${team.playersCount} players"
+            binding.imgTeamLogo.setImageResource(team.iconRes)
+            binding.root.setOnClickListener { onItemClick(team) }
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
@@ -17,12 +17,31 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentTeamsDetailBinding.bind(view)
 
+        val team = requireArguments().getSerializable("team") as? TeamModel
+
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
             findNavController().navigate(R.id.action_teamsDetailFragment_to_teamsEditFragment)
         }
+
+        team?.let { bindTeam(it) }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun bindTeam(team: TeamModel) {
+        binding.imageView2.setImageResource(team.iconRes)
+        binding.tvTeamName.text = team.name
+        binding.tvCityValue.text = team.city
+        binding.tvFoundedValue.text = team.foundedYear.toString()
+        binding.tvPlayersValue.text = team.playersCount.toString()
+
+        if (team.isDefault) {
+            binding.btnEdit.isEnabled = false
+            binding.btnDelete.isEnabled = false
+            binding.btnDelete.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
@@ -4,9 +4,16 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
+import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentTeamsEditBinding
+import androidx.lifecycle.lifecycleScope
+import androidx.room.Room
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
 
@@ -18,7 +25,46 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
         _binding = FragmentTeamsEditBinding.bind(view)
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+        binding.btnEdit.setOnClickListener { saveTeam() }
+        binding.btnDelete.visibility = View.GONE // no deletion when creating
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            findNavController().popBackStack()
+        }
+    }
+
+    private fun saveTeam() {
+        val name = binding.etTeamName.text.toString().trim()
+        val city = binding.etCity.text.toString().trim()
+        val founded = binding.etFoundedYear.text.toString().toIntOrNull() ?: 0
+        val playersCount = binding.etPlayersCount.text.toString().toIntOrNull() ?: 0
+        val notes = binding.etNotes.text.toString().trim()
+
+        val players = if (playersCount > 0) {
+            List(playersCount) { index ->
+                PlayerModel("Player ${index + 1}", "", index + 1)
+            }
+        } else emptyList()
+
+        val team = TeamModel(
+            name = name,
+            city = city,
+            foundedYear = founded,
+            notes = notes,
+            players = players,
+            iconRes = R.drawable.ic_users
+        )
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            val db = Room.databaseBuilder(requireContext(), AppDatabase::class.java, "app_db")
+                .fallbackToDestructiveMigration()
+                .build()
+            val teamId = withContext(Dispatchers.IO) { db.teamDao().insertTeam(team.toEntity()).toInt() }
+            val playerEntities = players.map { it.toEntity(teamId) }
+            if (playerEntities.isNotEmpty()) {
+                withContext(Dispatchers.IO) { db.playerDao().insertPlayers(playerEntities) }
+            }
+            setFragmentResult("add_team_result", Bundle())
             findNavController().popBackStack()
         }
     }

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsFragment.kt
@@ -4,28 +4,108 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.lifecycle.lifecycleScope
+import androidx.room.Room
 import com.besosn.app.R
+import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentTeamsBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
+/**
+ * Screen displaying list of teams. Allows navigating to team details
+ * and adding new teams.
+ */
 class TeamsFragment : Fragment(R.layout.fragment_teams) {
 
     private var _binding: FragmentTeamsBinding? = null
     private val binding get() = _binding!!
 
+    private lateinit var adapter: TeamsAdapter
+    private val teams = mutableListOf<TeamModel>()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentTeamsBinding.bind(view)
+
+        adapter = TeamsAdapter(teams) { team ->
+            val bundle = Bundle().apply { putSerializable("team", team) }
+            findNavController().navigate(R.id.action_teamsFragment_to_teamsDetailFragment, bundle)
+        }
+        binding.rvTeams.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvTeams.adapter = adapter
+
+        loadTeams()
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {
             findNavController().navigate(R.id.action_teamsFragment_to_teamsEditFragment)
         }
-        binding.rvTeams.setOnClickListener {
-            findNavController().navigate(R.id.action_teamsFragment_to_teamsDetailFragment)
+
+        // Listen for newly added team from edit screen and reload
+        setFragmentResultListener("add_team_result") { _, _ ->
+            loadTeams()
         }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun defaultTeams(): List<TeamModel> {
+        val team1 = TeamModel(
+            name = "YoungTeam",
+            city = "New York",
+            foundedYear = 2024,
+            notes = "Default team",
+            players = listOf(PlayerModel("Alex Finch", "FW", 10)),
+            iconRes = R.drawable.ic_users,
+            isDefault = true
+        )
+        val team2 = TeamModel(
+            name = "TalentTeam",
+            city = "Chicago",
+            foundedYear = 2021,
+            notes = "Default team",
+            players = listOf(PlayerModel("Yacob Sunny", "GK", 1)),
+            iconRes = R.drawable.ic_users,
+            isDefault = true
+        )
+        return listOf(team1, team2)
+    }
+
+    private fun loadTeams() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val db = Room.databaseBuilder(requireContext(), AppDatabase::class.java, "app_db")
+                .fallbackToDestructiveMigration()
+                .build()
+            val teamDao = db.teamDao()
+            val playerDao = db.playerDao()
+
+            val existing = withContext(Dispatchers.IO) { teamDao.getTeams() }
+            if (existing.isEmpty()) {
+                withContext(Dispatchers.IO) {
+                    defaultTeams().forEach { model ->
+                        val teamId = teamDao.insertTeam(model.toEntity()).toInt()
+                        playerDao.insertPlayers(model.players.map { it.toEntity(teamId) })
+                    }
+                }
+            }
+
+            val teamEntities = withContext(Dispatchers.IO) { teamDao.getTeams() }
+            val playerEntities = withContext(Dispatchers.IO) { playerDao.getPlayers() }
+            val playersByTeam = playerEntities.groupBy { it.teamId }
+            val models = teamEntities.map { entity ->
+                entity.toModel(playersByTeam[entity.id].orEmpty())
+            }
+
+            teams.clear()
+            teams.addAll(models)
+            adapter.notifyDataSetChanged()
         }
     }
 

--- a/app/src/main/res/layout/fragment_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_teams_detail.xml
@@ -93,6 +93,7 @@
             android:paddingTop="100dp">
 
             <TextView
+                android:id="@+id/tvTeamName"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="YOUNG\nTEAM"


### PR DESCRIPTION
## Summary
- expand team and player entities with full details
- load teams from Room and seed defaults to avoid duplicates
- save new teams and players to Room

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c795a6bf60832a842b5d6926293886