### PR TITLE
Implement team detail view with squad list and editing

### DIFF
--- a/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
@@ -14,6 +14,9 @@ interface PlayerDao {
     @Insert
     suspend fun insertPlayers(players: List<PlayerEntity>)
 
+    @Query("DELETE FROM players WHERE teamId = :teamId")
+    suspend fun deletePlayersByTeam(teamId: Int)
+
     @Delete
     suspend fun deletePlayer(player: PlayerEntity)
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayersAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayersAdapter.kt
@@ -1,0 +1,34 @@
+package com.besosn.app.presentation.ui.teams
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.databinding.PlayerItemBinding
+
+/**
+ * Adapter displaying list of players inside team detail screen.
+ */
+class PlayersAdapter(private val items: List<PlayerModel>) :
+    RecyclerView.Adapter<PlayersAdapter.PlayerViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlayerViewHolder {
+        val binding = PlayerItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PlayerViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: PlayerViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class PlayerViewHolder(private val binding: PlayerItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(player: PlayerModel) {
+            binding.tvPlayerName.text = player.fullName
+            binding.tvPlayerNumber.text = player.number.toString()
+            binding.tvPlayerPosition.text = player.position
+        }
+    }
+}
+

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
@@ -1,27 +1,57 @@
 package com.besosn.app.presentation.ui.teams
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.lifecycle.lifecycleScope
+import androidx.room.Room
 import com.besosn.app.R
+import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentTeamsDetailBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
+/**
+ * Screen displaying detailed information about a team.
+ */
 class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
 
     private var _binding: FragmentTeamsDetailBinding? = null
     private val binding get() = _binding!!
 
+    private var team: TeamModel? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentTeamsDetailBinding.bind(view)
 
-        val team = requireArguments().getSerializable("team") as? TeamModel
+        team = requireArguments().getSerializable("team") as? TeamModel
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
-            findNavController().navigate(R.id.action_teamsDetailFragment_to_teamsEditFragment)
+            team?.let {
+                val bundle = Bundle().apply { putSerializable("team", it) }
+                findNavController().navigate(
+                    R.id.action_teamsDetailFragment_to_teamsEditFragment,
+                    bundle
+                )
+            }
+        }
+        binding.btnDelete.setOnClickListener { confirmDelete() }
+
+        setFragmentResultListener("team_updated") { _, bundle ->
+            val updated = bundle.getSerializable("team") as? TeamModel
+            updated?.let {
+                team = it
+                bindTeam(it)
+            }
         }
 
         team?.let { bindTeam(it) }
@@ -32,16 +62,48 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
     }
 
     private fun bindTeam(team: TeamModel) {
-
+        binding.imgTeamIcon.setImageResource(
+            if (team.iconRes != 0) team.iconRes else R.drawable.ic_users
+        )
         binding.tvTeamName.text = team.name
         binding.tvCityValue.text = team.city
         binding.tvFoundedValue.text = team.foundedYear.toString()
         binding.tvPlayersValue.text = team.playersCount.toString()
+        binding.tvNotes.text = team.notes
+
+        binding.rvPlayers.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvPlayers.adapter = PlayersAdapter(team.players)
 
         if (team.isDefault) {
             binding.btnEdit.isEnabled = false
             binding.btnDelete.isEnabled = false
             binding.btnDelete.visibility = View.GONE
+        } else {
+            binding.btnEdit.isEnabled = true
+            binding.btnDelete.isEnabled = true
+            binding.btnDelete.visibility = View.VISIBLE
+        }
+    }
+
+    private fun confirmDelete() {
+        AlertDialog.Builder(requireContext())
+            .setMessage("Please confirm delete action before continuing")
+            .setNegativeButton("Cancel", null)
+            .setPositiveButton("Confirm") { _, _ -> team?.let { deleteTeam(it) } }
+            .show()
+    }
+
+    private fun deleteTeam(team: TeamModel) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val db = Room.databaseBuilder(requireContext(), AppDatabase::class.java, "app_db")
+                .fallbackToDestructiveMigration()
+                .build()
+            withContext(Dispatchers.IO) {
+                db.playerDao().deletePlayersByTeam(team.id)
+                db.teamDao().deleteTeam(team.toEntity())
+            }
+            setFragmentResult("add_team_result", Bundle())
+            findNavController().popBackStack()
         }
     }
 
@@ -50,3 +112,4 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         _binding = null
     }
 }
+

--- a/app/src/main/res/layout/fragment_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_teams_detail.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="@drawable/bg_teams_dark">
     <ImageView
-        android:id="@+id/imageView2"
+        android:id="@+id/imgTeamIcon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:src="@drawable/logo"
@@ -219,7 +219,7 @@
                 android:textAllCaps="true"/>
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
+                android:id="@+id/rvPlayers"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:overScrollMode="never"/>
@@ -243,12 +243,13 @@
                 android:textAllCaps="true"/>
 
             <TextView
+                android:id="@+id/tvNotes"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:textSize="16sp"
                 android:fontFamily="@font/poppins_regular"
                 android:textColor="#A2FFFFFF"
-                android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-                android:layout_height="wrap_content"/>
+                android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."/>
         </LinearLayout>
 
     </FrameLayout>

--- a/app/src/main/res/layout/player_item.xml
+++ b/app/src/main/res/layout/player_item.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvPlayerNumber"
+        android:layout_width="40dp"
+        android:layout_height="wrap_content"
+        android:text="10"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:fontFamily="@font/poppins_regular" />
+
+    <TextView
+        android:id="@+id/tvPlayerName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Player Name"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:fontFamily="@font/poppins_regular"
+        android:paddingStart="8dp" />
+
+    <TextView
+        android:id="@+id/tvPlayerPosition"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="FW"
+        android:textColor="#B3FFFFFF"
+        android:textSize="16sp"
+        android:fontFamily="@font/poppins_regular" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- show team icon, notes, and player squad on detail screen
- allow editing existing teams with pre-filled data
- support deleting team with confirmation and cleanup of related players

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79ccad794832aab176131db3ea057