### PR TITLE
Add TeamsEdit screen with player management

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
@@ -3,18 +3,26 @@ package com.besosn.app.presentation.ui.teams
 import android.net.Uri
 import android.os.Bundle
 import android.text.InputFilter
+import android.view.LayoutInflater
 import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.Spinner
+import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.AppCompatButton
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.lifecycle.lifecycleScope
+import androidx.room.Room
 import com.besosn.app.R
 import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentTeamsEditBinding
-import androidx.lifecycle.lifecycleScope
-import androidx.room.Room
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,6 +33,8 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
     private val binding get() = _binding!!
     private var editingTeam: TeamModel? = null
     private var selectedIconUri: String? = null
+    private val players = mutableListOf<PlayerModel>()
+    private lateinit var playersAdapter: PlayersAdapter
 
     private val pickImage = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         uri?.let {
@@ -47,18 +57,21 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener { saveTeam() }
-        binding.btnDelete.visibility = View.GONE // no deletion from edit screen
+        binding.btnCancel.setOnClickListener { findNavController().popBackStack() }
+
+        playersAdapter = PlayersAdapter(players)
+        binding.rvPlayers.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvPlayers.adapter = playersAdapter
+        binding.btnAddPlayer.setOnClickListener { showAddPlayerDialog() }
 
         binding.imageView2.setOnClickListener {
             pickImage.launch("image/*")
         }
 
-
         editingTeam?.let { team ->
             binding.etTeamName.setText(team.name)
             binding.etCity.setText(team.city)
             binding.etFoundedYear.setText(team.foundedYear.toString())
-            binding.etPlayersCount.setText(team.playersCount.toString())
             binding.etNotes.setText(team.notes)
             selectedIconUri = team.iconUri
             if (team.iconUri != null) {
@@ -66,7 +79,8 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
             } else if (team.iconRes != 0) {
                 binding.imageView2.setImageResource(team.iconRes)
             }
-
+            players.addAll(team.players)
+            playersAdapter.notifyDataSetChanged()
         }
 
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
@@ -78,49 +92,17 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
         val name = binding.etTeamName.text.toString().trim()
         val city = binding.etCity.text.toString().trim()
         val foundedStr = binding.etFoundedYear.text.toString().trim()
-        val playersStr = binding.etPlayersCount.text.toString().trim()
         val notes = binding.etNotes.text.toString().trim()
+        val founded = foundedStr.toIntOrNull()
 
-        when {
-            name.isEmpty() -> {
-                binding.etTeamName.error = "Required"
-                return
-            }
-            city.isEmpty() -> {
-                binding.etCity.error = "Required"
-                return
-            }
-            foundedStr.isEmpty() -> {
-                binding.etFoundedYear.error = "Required"
-                return
-            }
-            playersStr.isEmpty() -> {
-                binding.etPlayersCount.error = "Required"
-                return
-            }
-        }
-
-        val founded = foundedStr.toIntOrNull() ?: 0
-        val playersCount = playersStr.toIntOrNull() ?: 0
-
-        if (founded <= 0) {
-            binding.etFoundedYear.error = "Invalid"
+        if (name.isEmpty() || city.isEmpty() || foundedStr.isEmpty() ||
+            notes.isEmpty() || players.isEmpty() || founded == null) {
+            Toast.makeText(requireContext(), getString(R.string.fill_all_fields), Toast.LENGTH_SHORT).show()
             return
         }
-        if (playersCount <= 0) {
-            binding.etPlayersCount.error = "Invalid"
-            return
-        }
-
-
-        val players = if (playersCount > 0) {
-            List(playersCount) { index ->
-                PlayerModel("Player ${index + 1}", "", index + 1)
-            }
-        } else emptyList()
 
         val iconUri = selectedIconUri ?: editingTeam?.iconUri
-
+        val currentPlayers = players.toList()
 
         val existing = editingTeam
         if (existing != null) {
@@ -129,10 +111,9 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
                 city = city,
                 foundedYear = founded,
                 notes = notes,
-                players = players,
+                players = currentPlayers,
                 iconUri = iconUri,
                 iconRes = if (iconUri != null) 0 else existing.iconRes
-
             )
             viewLifecycleOwner.lifecycleScope.launch {
                 val db = Room.databaseBuilder(requireContext(), AppDatabase::class.java, "app_db")
@@ -141,7 +122,7 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
                 withContext(Dispatchers.IO) {
                     db.teamDao().updateTeam(updatedTeam.toEntity())
                     db.playerDao().deletePlayersByTeam(updatedTeam.id)
-                    val playerEntities = players.map { it.toEntity(updatedTeam.id) }
+                    val playerEntities = currentPlayers.map { it.toEntity(updatedTeam.id) }
                     if (playerEntities.isNotEmpty()) {
                         db.playerDao().insertPlayers(playerEntities)
                     }
@@ -156,10 +137,9 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
                 city = city,
                 foundedYear = founded,
                 notes = notes,
-                players = players,
+                players = currentPlayers,
                 iconUri = iconUri,
                 iconRes = if (iconUri != null) 0 else R.drawable.ic_users
-
             )
 
             viewLifecycleOwner.lifecycleScope.launch {
@@ -167,7 +147,7 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
                     .fallbackToDestructiveMigration()
                     .build()
                 val teamId = withContext(Dispatchers.IO) { db.teamDao().insertTeam(team.toEntity()).toInt() }
-                val playerEntities = players.map { it.toEntity(teamId) }
+                val playerEntities = currentPlayers.map { it.toEntity(teamId) }
                 if (playerEntities.isNotEmpty()) {
                     withContext(Dispatchers.IO) { db.playerDao().insertPlayers(playerEntities) }
                 }
@@ -175,6 +155,42 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
                 findNavController().popBackStack()
             }
         }
+    }
+
+    private fun showAddPlayerDialog() {
+        val dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_add_player, null)
+        val etName = dialogView.findViewById<EditText>(R.id.etPlayerName)
+        val etNumber = dialogView.findViewById<EditText>(R.id.etNumber)
+        val spPosition = dialogView.findViewById<Spinner>(R.id.spPosition)
+        val btnAdd = dialogView.findViewById<AppCompatButton>(R.id.btnAddPlayer)
+        val btnCancel = dialogView.findViewById<AppCompatButton>(R.id.btnCancel)
+
+        val positions = resources.getStringArray(R.array.player_positions)
+        val spinnerAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, positions)
+        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spPosition.adapter = spinnerAdapter
+
+        val dialog = AlertDialog.Builder(requireContext()).setView(dialogView).create()
+
+        btnAdd.setOnClickListener {
+            val name = etName.text.toString().trim()
+            val numberStr = etNumber.text.toString().trim()
+            val position = spPosition.selectedItem.toString()
+
+            val number = numberStr.toIntOrNull()
+            if (name.isEmpty() || numberStr.isEmpty() || number == null) {
+                Toast.makeText(requireContext(), getString(R.string.fill_all_fields), Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            players.add(PlayerModel(name, position, number))
+            playersAdapter.notifyDataSetChanged()
+            dialog.dismiss()
+        }
+
+        btnCancel.setOnClickListener { dialog.dismiss() }
+
+        dialog.show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/dialog_add_player.xml
+++ b/app/src/main/res/layout/dialog_add_player.xml
@@ -160,13 +160,19 @@
                 android:layout_width="12dp"
                 android:layout_height="1dp" />
 
-            <ImageButton
-                android:id="@+id/btnDelete"
-                android:layout_width="56dp"
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btnCancel"
+                android:layout_width="0dp"
                 android:layout_height="56dp"
+                android:layout_weight="1"
                 android:background="@drawable/btn_delete_gradient"
-                android:src="@drawable/ic_delete"
-                android:scaleType="centerInside" />
+                android:text="Cancel"
+                android:textAllCaps="false"
+                android:textColor="@android:color/white"
+                android:textStyle="bold"
+                android:textFontWeight="700"
+                android:fontFamily="@font/unbounded"
+                android:textSize="24sp"/>
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_teams_edit.xml
+++ b/app/src/main/res/layout/fragment_teams_edit.xml
@@ -12,7 +12,7 @@
         android:background="@drawable/rounded_12"
         android:clipToOutline="true"
         android:layout_gravity="center_horizontal"
-        android:src="@drawable/ic_launcher_background"
+        android:src="@drawable/ic_users"
         android:scaleType="centerCrop"
         android:layout_marginTop="40dp"
         android:elevation="1dp"
@@ -53,15 +53,17 @@
             android:layout_width="12dp"
             android:layout_height="wrap_content" />
 
-        <ImageButton
-            android:id="@+id/btnDelete"
-            android:layout_width="56dp"
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnCancel"
+            android:layout_width="0dp"
             android:layout_height="56dp"
-
+            android:layout_weight="1"
+            android:text="Cancel"
+            android:textStyle="bold"
+            android:textColor="@android:color/white"
             android:background="@drawable/btn_delete_gradient"
-            android:src="@drawable/trash_icon"
-            android:scaleType="centerInside"
-            android:contentDescription="Delete"/>
+            android:fontFamily="@font/unbounded"
+            android:textSize="18sp"/>
     </LinearLayout>
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
@@ -150,83 +152,37 @@
                         android:textSize="16sp"/>
                 </LinearLayout>
 
-                <!-- Родительский контейнер -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
+                    android:orientation="vertical"
                     android:layout_marginTop="16dp">
 
-                    <!-- Col #1: Founded -->
-                    <LinearLayout
-                        android:layout_width="0dp"
+                    <TextView
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:paddingEnd="8dp">
+                        android:text="Founded"
+                        android:textColor="@android:color/white"
+                        android:textSize="18sp"
+                        android:includeFontPadding="false"
+                        android:fontFamily="@font/poppins_regular"
+                        android:layout_marginBottom="8dp"/>
 
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Founded"
-                            android:textColor="@android:color/white"
-                            android:textSize="18sp"
-                            android:includeFontPadding="false"
-                            android:fontFamily="@font/poppins_regular"
-                            android:layout_marginBottom="8dp"/>
-
-                        <EditText
-                            android:id="@+id/etFoundedYear"
-                            android:layout_width="match_parent"
-                            android:layout_height="60dp"
-                            android:background="@drawable/bg_input_team"
-                            android:hint="Enter year"
-                            android:textColor="@android:color/white"
-                            android:textColorHint="#72FFFFFF"
-                            android:paddingHorizontal="16dp"
-                            android:fontFamily="@font/poppins_regular"
-                            android:textSize="16sp"
-                            android:inputType="number"
-                            android:maxLength="4"
-                            android:gravity="center_vertical"
-                            android:singleLine="true"/>
-                    </LinearLayout>
-
-                    <!-- Col #2: Players -->
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:paddingStart="8dp">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Players"
-                            android:textColor="@android:color/white"
-                            android:textSize="18sp"
-                            android:includeFontPadding="false"
-                            android:fontFamily="@font/poppins_regular"
-                            android:layout_marginBottom="8dp"/>
-
-                        <EditText
-                            android:id="@+id/etPlayersCount"
-                            android:layout_width="match_parent"
-                            android:layout_height="60dp"
-                            android:background="@drawable/bg_input_team"
-                            android:hint="0"
-                            android:textColor="@android:color/white"
-                            android:textColorHint="#72FFFFFF"
-                            android:paddingHorizontal="16dp"
-                            android:fontFamily="@font/poppins_regular"
-                            android:textSize="16sp"
-                            android:inputType="number"
-                            android:maxLength="2"
-                            android:gravity="center_vertical"
-                            android:singleLine="true"/>
-                    </LinearLayout>
-
+                    <EditText
+                        android:id="@+id/etFoundedYear"
+                        android:layout_width="match_parent"
+                        android:layout_height="60dp"
+                        android:background="@drawable/bg_input_team"
+                        android:hint="Enter year"
+                        android:textColor="@android:color/white"
+                        android:textColorHint="#72FFFFFF"
+                        android:paddingHorizontal="16dp"
+                        android:fontFamily="@font/poppins_regular"
+                        android:textSize="16sp"
+                        android:inputType="number"
+                        android:maxLength="4"
+                        android:gravity="center_vertical"
+                        android:singleLine="true"/>
                 </LinearLayout>
 
 
@@ -242,7 +198,6 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:layout_marginTop="10dp"
-
                     android:orientation="horizontal">
 
                     <TextView
@@ -257,7 +212,7 @@
                         android:textAllCaps="true"/>
 
                     <LinearLayout
-                        android:id="@+id/btnSettings"
+                        android:id="@+id/btnAddPlayer"
                         android:layout_width="0dp"
                         android:layout_height="45dp"
                         android:layout_weight="1"
@@ -281,8 +236,12 @@
                             android:fontFamily="@font/unbounded"/>
                     </LinearLayout>
                 </LinearLayout>
-
-
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvPlayers"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:nestedScrollingEnabled="false"/>
 
                 <View
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,8 @@
+<resources>
+    <string-array name="player_positions">
+        <item>GK</item>
+        <item>DF</item>
+        <item>MF</item>
+        <item>FW</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Besosn</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="fill_all_fields">Fill all fields to save team data.</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow adding/removing squad members in TeamsEdit screen with Add Player dialog
- save team and player data to Room and provide Cancel action
- add spinner options and validation message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a3e2b9ec832a94b8482a87c8ece4