### PR TITLE
Implement inventory screen with add edit and delete

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".BesosnApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/besosn/app/BesosnApp.kt
+++ b/app/src/main/java/com/besosn/app/BesosnApp.kt
@@ -1,0 +1,8 @@
+package com.besosn.app
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class BesosnApp : Application()
+

--- a/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
@@ -21,7 +21,7 @@ import com.besosn.app.data.local.db.dao.TeamDao
         InventoryEntity::class,
         ArticleEntity::class
     ],
-    version = 4
+    version = 5
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun teamDao(): TeamDao

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/InventoryDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/InventoryDao.kt
@@ -9,7 +9,7 @@ interface InventoryDao {
     @Query("SELECT * FROM inventory")
     fun getItems(): Flow<List<InventoryEntity>>
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertItem(item: InventoryEntity)
 
     @Delete

--- a/app/src/main/java/com/besosn/app/data/model/InventoryEntity.kt
+++ b/app/src/main/java/com/besosn/app/data/model/InventoryEntity.kt
@@ -7,6 +7,9 @@ import androidx.room.PrimaryKey
 data class InventoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val name: String,
-    val quantity: Int
+    val quantity: Int,
+    val category: String,
+    val badge: String,
+    val notes: String
 )
 

--- a/app/src/main/java/com/besosn/app/data/repository/InventoryRepositoryImpl.kt
+++ b/app/src/main/java/com/besosn/app/data/repository/InventoryRepositoryImpl.kt
@@ -1,14 +1,46 @@
 package com.besosn.app.data.repository
 
+import com.besosn.app.data.local.db.AppDatabase
+import com.besosn.app.data.model.InventoryEntity
 import com.besosn.app.domain.model.InventoryItem
 import com.besosn.app.domain.repository.InventoryRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class InventoryRepositoryImpl @Inject constructor() : InventoryRepository {
-    override fun getItems(): Flow<List<InventoryItem>> = flow { emit(emptyList()) }
-    override suspend fun addItem(item: InventoryItem) { /* TODO */ }
-    override suspend fun deleteItem(item: InventoryItem) { /* TODO */ }
+class InventoryRepositoryImpl @Inject constructor(
+    private val db: AppDatabase
+) : InventoryRepository {
+
+    private val dao = db.inventoryDao()
+
+    override fun getItems(): Flow<List<InventoryItem>> =
+        dao.getItems().map { entities -> entities.map { it.toDomain() } }
+
+    override suspend fun addItem(item: InventoryItem) {
+        dao.insertItem(item.toEntity())
+    }
+
+    override suspend fun deleteItem(item: InventoryItem) {
+        dao.deleteItem(item.toEntity())
+    }
+
+    private fun InventoryEntity.toDomain() = InventoryItem(
+        id = id,
+        name = name,
+        quantity = quantity,
+        category = category,
+        badge = badge,
+        notes = notes
+    )
+
+    private fun InventoryItem.toEntity() = InventoryEntity(
+        id = id,
+        name = name,
+        quantity = quantity,
+        category = category,
+        badge = badge,
+        notes = notes
+    )
 }
 

--- a/app/src/main/java/com/besosn/app/domain/model/InventoryItem.kt
+++ b/app/src/main/java/com/besosn/app/domain/model/InventoryItem.kt
@@ -1,8 +1,16 @@
 package com.besosn.app.domain.model
 
+import java.io.Serializable
+
+/**
+ * Domain model representing a single item in the inventory.
+ */
 data class InventoryItem(
     val id: Int = 0,
     val name: String,
-    val quantity: Int
-)
+    val quantity: Int,
+    val category: String,
+    val badge: String,
+    val notes: String
+) : Serializable
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryAdapter.kt
@@ -1,0 +1,45 @@
+package com.besosn.app.presentation.ui.inventory
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.databinding.ItemInventoryBinding
+import com.besosn.app.domain.model.InventoryItem
+
+/**
+ * Adapter displaying inventory items.
+ */
+class InventoryAdapter(
+    private val items: MutableList<InventoryItem>,
+    private val onEdit: (InventoryItem) -> Unit,
+    private val onDelete: (InventoryItem) -> Unit
+) : RecyclerView.Adapter<InventoryAdapter.InventoryViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InventoryViewHolder {
+        val binding = ItemInventoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return InventoryViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: InventoryViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(newItems: List<InventoryItem>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+
+    inner class InventoryViewHolder(private val binding: ItemInventoryBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: InventoryItem) {
+            binding.tvName.text = item.name
+            binding.tvQuantity.text = "Qty: ${item.quantity}"
+            binding.tvCategory.text = item.category
+            binding.tvBadge.text = item.badge
+            binding.btnEdit.setOnClickListener { onEdit(item) }
+            binding.btnDelete.setOnClickListener { onDelete(item) }
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryEditFragment.kt
@@ -6,27 +6,37 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.PopupWindow
 import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentInventoryEditBinding
+import com.besosn.app.domain.model.InventoryItem
+import com.besosn.app.presentation.viewmodel.InventoryViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class InventoryEditFragment : Fragment() {
 
     private var _binding: FragmentInventoryEditBinding? = null
     private val binding get() = _binding!!
 
+    private val viewModel: InventoryViewModel by viewModels()
+    private var currentItem: InventoryItem? = null
+
     private lateinit var popup: PopupWindow
     private val categories = listOf("Balls", "Cones", "Bibs", "Nets", "Med")
+    private val badges = listOf("New", "Used", "Damaged")
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentInventoryEditBinding.inflate(inflater, container, false)
         return binding.root
@@ -35,19 +45,65 @@ class InventoryEditFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setupDropdown()
+        currentItem = arguments?.getSerializable("item") as? InventoryItem
+
+        setupDropdown(binding.ddCategory, binding.tvCategory, binding.ivCategoryArrow, categories)
+        setupDropdown(binding.ddCategoryAnchor, binding.tvCategoryValue, binding.ivCategoryArrow1, badges)
+
+        if (currentItem != null) {
+            binding.etTeamName.setText(currentItem!!.name)
+            binding.etCity.setText(currentItem!!.quantity.toString())
+            binding.tvCategory.text = currentItem!!.category
+            binding.tvCategory.setTextColor(Color.WHITE)
+            binding.tvCategoryValue.text = currentItem!!.badge
+            binding.tvCategoryValue.setTextColor(Color.WHITE)
+            binding.etNotes.setText(currentItem!!.notes)
+        } else {
+            binding.btnDelete.visibility = View.GONE
+        }
+
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+        binding.btnEdit.setOnClickListener { saveItem() }
+        binding.btnDelete.setOnClickListener { confirmDelete() }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
     }
 
-    private fun setupDropdown() {
-        val anchor = binding.ddCategoryAnchor    // FrameLayout
-        val tv = binding.tvCategoryValue         // TextView внутри
-        val arrow = binding.ivCategoryArrow      // ImageView стрелка
+    private fun saveItem() {
+        val name = binding.etTeamName.text.toString()
+        val quantity = binding.etCity.text.toString().toIntOrNull() ?: 0
+        val category = binding.tvCategory.text.toString()
+        val badge = binding.tvCategoryValue.text.toString()
+        val notes = binding.etNotes.text.toString()
 
-        anchor.setOnClickListener {
+        val item = InventoryItem(
+            id = currentItem?.id ?: 0,
+            name = name,
+            quantity = quantity,
+            category = category,
+            badge = badge,
+            notes = notes
+        )
+        viewModel.addItem(item)
+        findNavController().popBackStack()
+    }
+
+    private fun confirmDelete() {
+        val item = currentItem ?: return
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setMessage("Please confirm delete action before continuing")
+            .setPositiveButton("Confirm") { _, _ ->
+                viewModel.deleteItem(item)
+                findNavController().popBackStack()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun setupDropdown(anchorView: FrameLayout, tv: TextView, arrow: View, list: List<String>) {
+        anchorView.setOnClickListener {
             if (::popup.isInitialized && popup.isShowing) {
                 popup.dismiss()
                 return@setOnClickListener
@@ -63,13 +119,13 @@ class InventoryEditFragment : Fragment() {
                 override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
                     VH(LayoutInflater.from(parent.context)
                         .inflate(R.layout.item_dropdown_row, parent, false))
-                override fun getItemCount() = categories.size
+                override fun getItemCount() = list.size
                 override fun onBindViewHolder(holder: VH, pos: Int) {
-                    holder.txt.text = categories[pos]
+                    holder.txt.text = list[pos]
                     holder.divider.visibility =
-                        if (pos == categories.lastIndex) View.GONE else View.VISIBLE
+                        if (pos == list.lastIndex) View.GONE else View.VISIBLE
                     holder.itemView.setOnClickListener {
-                        tv.text = categories[pos]
+                        tv.text = list[pos]
                         tv.setTextColor(Color.WHITE)
                         popup.dismiss()
                     }
@@ -78,7 +134,7 @@ class InventoryEditFragment : Fragment() {
 
             popup = PopupWindow(
                 content,
-                anchor.width,
+                anchorView.width,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 true
             ).apply {
@@ -89,7 +145,7 @@ class InventoryEditFragment : Fragment() {
             }
 
             arrow.animate().rotation(180f).setDuration(120).start()
-            popup.showAsDropDown(anchor, 0, 8)
+            popup.showAsDropDown(anchorView, 0, 8)
         }
     }
 
@@ -103,3 +159,4 @@ class InventoryEditFragment : Fragment() {
         _binding = null
     }
 }
+

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryFragment.kt
@@ -4,29 +4,62 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentInventoryBinding
+import com.besosn.app.domain.model.InventoryItem
+import com.besosn.app.presentation.viewmodel.InventoryViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 
+@AndroidEntryPoint
 class InventoryFragment : Fragment(R.layout.fragment_inventory) {
 
     private var _binding: FragmentInventoryBinding? = null
     private val binding get() = _binding!!
 
+    private val viewModel: InventoryViewModel by viewModels()
+    private lateinit var adapter: InventoryAdapter
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentInventoryBinding.bind(view)
+
+        adapter = InventoryAdapter(mutableListOf(), ::onEditItem, ::onDeleteItem)
+        binding.rvInventory.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvInventory.adapter = adapter
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {
             findNavController().navigate(R.id.action_inventoryFragment_to_inventoryEditFragment)
         }
-        binding.rvTeams.setOnClickListener {
-            findNavController().navigate(R.id.action_inventoryFragment_to_inventoryDetailFragment)
+
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.items.collectLatest { items ->
+                adapter.submitList(items)
+                binding.tvEmpty.visibility = if (items.isEmpty()) View.VISIBLE else View.GONE
+            }
         }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+    }
+
+    private fun onEditItem(item: InventoryItem) {
+        val bundle = Bundle().apply { putSerializable("item", item) }
+        findNavController().navigate(R.id.action_inventoryFragment_to_inventoryEditFragment, bundle)
+    }
+
+    private fun onDeleteItem(item: InventoryItem) {
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setMessage("Please confirm delete action before continuing")
+            .setPositiveButton("Confirm") { _, _ -> viewModel.deleteItem(item) }
+            .setNegativeButton("Cancel", null)
+            .show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/besosn/app/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/main/MainActivity.kt
@@ -6,7 +6,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import com.besosn.app.R
 import com.besosn.app.utils.Constants
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/besosn/app/presentation/viewmodel/InventoryViewModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/viewmodel/InventoryViewModel.kt
@@ -1,9 +1,34 @@
 package com.besosn.app.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.besosn.app.domain.model.InventoryItem
+import com.besosn.app.domain.usecase.inventory.AddInventoryItemUseCase
+import com.besosn.app.domain.usecase.inventory.DeleteInventoryItemUseCase
+import com.besosn.app.domain.usecase.inventory.GetInventoryItemsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class InventoryViewModel @Inject constructor() : ViewModel()
+class InventoryViewModel @Inject constructor(
+    private val addInventoryItemUseCase: AddInventoryItemUseCase,
+    getInventoryItemsUseCase: GetInventoryItemsUseCase,
+    private val deleteInventoryItemUseCase: DeleteInventoryItemUseCase
+) : ViewModel() {
+
+    val items: StateFlow<List<InventoryItem>> = getInventoryItemsUseCase()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun addItem(item: InventoryItem) {
+        viewModelScope.launch { addInventoryItemUseCase(item) }
+    }
+
+    fun deleteItem(item: InventoryItem) {
+        viewModelScope.launch { deleteInventoryItemUseCase(item) }
+    }
+}
 

--- a/app/src/main/res/layout/fragment_inventory.xml
+++ b/app/src/main/res/layout/fragment_inventory.xml
@@ -34,9 +34,9 @@
         android:layout_marginStart="15dp"
         android:layout_marginEnd="16dp"/>
 
-    <!-- Список команд (пустой) -->
+    <!-- Inventory list -->
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvTeams"
+        android:id="@+id/rvInventory"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:clipToPadding="false"
@@ -48,6 +48,20 @@
         app:layout_constraintBottom_toTopOf="@+id/bottomBar"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvEmpty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No Inventory yet"
+        android:textColor="@android:color/white"
+        android:textSize="18sp"
+        android:fontFamily="@font/unbounded"
+        app:layout_constraintTop_toBottomOf="@id/btnBack"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:visibility="gone"/>
 
     <!-- Нижняя панель с кнопкой -->
     <LinearLayout

--- a/app/src/main/res/layout/item_inventory.xml
+++ b/app/src/main/res/layout/item_inventory.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="80dp"
+    android:background="@drawable/bg_team_item"
+    android:padding="12dp">
+
+    <ImageView
+        android:id="@+id/ivIcon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/ball"
+        android:background="@drawable/bg_circle"
+        android:scaleType="centerCrop"
+        android:clipToOutline="true"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:text="Item"
+        android:textColor="@android:color/white"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        app:layout_constraintStart_toEndOf="@id/ivIcon"
+        app:layout_constraintTop_toTopOf="@id/ivIcon"
+        app:layout_constraintEnd_toStartOf="@id/btnEdit"/>
+
+    <TextView
+        android:id="@+id/tvQuantity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Qty: 0"
+        android:textColor="#B3FFFFFF"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="@id/tvName"
+        app:layout_constraintTop_toBottomOf="@id/tvName"/>
+
+    <TextView
+        android:id="@+id/tvCategory"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:text="Category"
+        android:textColor="#B3FFFFFF"
+        android:textSize="14sp"
+        app:layout_constraintStart_toEndOf="@id/tvQuantity"
+        app:layout_constraintBaseline_toBaselineOf="@id/tvQuantity"/>
+
+    <TextView
+        android:id="@+id/tvBadge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/bg_outline_orange"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="2dp"
+        android:text="Badge"
+        android:textColor="#FC4F08"
+        android:textSize="12sp"
+        app:layout_constraintStart_toEndOf="@id/tvCategory"
+        app:layout_constraintBaseline_toBaselineOf="@id/tvCategory"/>
+
+    <ImageButton
+        android:id="@+id/btnEdit"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:background="@drawable/btn_edit_gradient"
+        android:contentDescription="Edit"
+        android:src="@drawable/ic_plus"
+        android:scaleType="center"
+        app:layout_constraintEnd_toStartOf="@id/btnDelete"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <ImageButton
+        android:id="@+id/btnDelete"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/btn_delete_gradient"
+        android:contentDescription="Delete"
+        android:src="@drawable/trash_icon"
+        android:scaleType="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add InventoryItem model and Room entity fields for category, badge, and notes
- create repository, view model, adapter, and layouts to manage inventory list with add, edit, and delete actions
- show empty state when no inventory and handle item deletion confirmations
- configure Hilt application and annotate MainActivity to prevent fragment injection crashes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b5e6b000832abf65911e964ed510