### PR TITLE
Add match list with filters and empty state

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
@@ -1,0 +1,20 @@
+package com.besosn.app.presentation.ui.matches
+
+import androidx.annotation.DrawableRes
+import java.io.Serializable
+
+/**
+ * UI model describing a single match shown on the Matches screen.
+ */
+data class MatchModel(
+    val id: Int = 0,
+    val homeTeam: String,
+    val awayTeam: String,
+    @DrawableRes val homeIconRes: Int,
+    @DrawableRes val awayIconRes: Int,
+    val date: Long,
+    val homeScore: Int? = null,
+    val awayScore: Int? = null
+) : Serializable {
+    val isFinished: Boolean get() = homeScore != null && awayScore != null
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
@@ -1,0 +1,51 @@
+package com.besosn.app.presentation.ui.matches
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.databinding.MatchItemBinding
+import java.text.SimpleDateFormat
+import java.util.*
+
+/**
+ * Adapter displaying list of matches on the [MatchesFragment].
+ */
+class MatchesAdapter(
+    private val items: MutableList<MatchModel>,
+    private val onItemClick: (MatchModel) -> Unit
+) : RecyclerView.Adapter<MatchesAdapter.MatchViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MatchViewHolder {
+        val binding = MatchItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MatchViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: MatchViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(matches: List<MatchModel>) {
+        items.clear()
+        items.addAll(matches)
+        notifyDataSetChanged()
+    }
+
+    inner class MatchViewHolder(private val binding: MatchItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(match: MatchModel) {
+            val dateFormat = SimpleDateFormat("dd.MM.yyyy - HH:mm", Locale.getDefault())
+            binding.tvMatchDate.text = dateFormat.format(Date(match.date))
+            binding.tvTeam1.text = match.homeTeam
+            binding.tvTeam2.text = match.awayTeam
+            binding.imgTeamLogo.setImageResource(match.homeIconRes)
+            binding.imgTeamLogo2.setImageResource(match.awayIconRes)
+            binding.tvMatchScore.text = if (match.isFinished) {
+                "${match.homeScore}:${match.awayScore}"
+            } else {
+                "Scheduled"
+            }
+            binding.root.setOnClickListener { onItemClick(match) }
+        }
+    }
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
@@ -5,28 +5,94 @@ import android.view.View
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentMatchesBinding
+import java.util.Calendar
 
 class MatchesFragment : Fragment(R.layout.fragment_matches) {
 
     private var _binding: FragmentMatchesBinding? = null
     private val binding get() = _binding!!
 
+    private lateinit var adapter: MatchesAdapter
+    private val matches = mutableListOf<MatchModel>()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentMatchesBinding.bind(view)
+
+        adapter = MatchesAdapter(mutableListOf()) {
+            findNavController().navigate(R.id.action_matchesFragment_to_matchDetailFragment)
+        }
+        binding.rvMatches.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvMatches.adapter = adapter
+
+        loadMatches()
+        setupFilters()
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {
             findNavController().navigate(R.id.action_matchesFragment_to_matchEditFragment)
         }
-        binding.rvMatches.setOnClickListener {
-            findNavController().navigate(R.id.action_matchesFragment_to_matchDetailFragment)
-        }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+    }
+
+    private fun loadMatches() {
+        matches.clear()
+        val now = Calendar.getInstance()
+        val past = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -1) }
+        val future = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, 3) }
+
+        matches.add(
+            MatchModel(
+                id = 1,
+                homeTeam = "Barcelona",
+                awayTeam = "Real Madrid",
+                homeIconRes = R.drawable.vdgdsgfds,
+                awayIconRes = R.drawable.jkljfsjfls,
+                date = past.timeInMillis,
+                homeScore = 1,
+                awayScore = 2
+            )
+        )
+        matches.add(
+            MatchModel(
+                id = 2,
+                homeTeam = "Arsenal",
+                awayTeam = "Chelsea",
+                homeIconRes = R.drawable.vdgdsgfds,
+                awayIconRes = R.drawable.jkljfsjfls,
+                date = future.timeInMillis
+            )
+        )
+        applyFilter(MatchFilter.ALL)
+    }
+
+    private fun setupFilters() {
+        binding.rgTabs.setOnCheckedChangeListener { _, checkedId ->
+            val filter = when (checkedId) {
+                R.id.tabScheduled -> MatchFilter.SCHEDULED
+                R.id.tabFinished -> MatchFilter.FINISHED
+                else -> MatchFilter.ALL
+            }
+            applyFilter(filter)
+        }
+    }
+
+    private fun applyFilter(filter: MatchFilter) {
+        val filtered = when (filter) {
+            MatchFilter.ALL -> matches
+            MatchFilter.SCHEDULED -> matches.filter { !it.isFinished }
+            MatchFilter.FINISHED -> matches.filter { it.isFinished }
+        }.sortedBy { it.date }
+
+        adapter.submitList(filtered)
+        val empty = filtered.isEmpty()
+        binding.tvEmpty.visibility = if (empty) View.VISIBLE else View.GONE
+        binding.rvMatches.visibility = if (empty) View.GONE else View.VISIBLE
     }
 
     override fun onDestroyView() {
@@ -34,3 +100,5 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
         _binding = null
     }
 }
+
+private enum class MatchFilter { ALL, SCHEDULED, FINISHED }

--- a/app/src/main/res/layout/fragment_matches.xml
+++ b/app/src/main/res/layout/fragment_matches.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:gravity="center"
     android:orientation="vertical">
 
@@ -11,27 +11,27 @@
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:src="@drawable/back"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="18dp"/>
+        android:layout_marginTop="18dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/tvTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Inventory"
+        android:text="Matches"
         android:textAllCaps="true"
         android:textColor="#FC4F08"
         android:textStyle="bold"
         android:fontFamily="@font/unbounded"
         android:textSize="36sp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="16dp"
         app:layout_constraintStart_toEndOf="@id/btnBack"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/btnBack"
-        app:layout_constraintBottom_toBottomOf="@id/btnBack"
-        android:layout_marginStart="15dp"
-        android:layout_marginEnd="16dp"/>
+        app:layout_constraintBottom_toBottomOf="@id/btnBack" />
 
     <LinearLayout
         android:id="@+id/segmentedContainer"
@@ -41,8 +41,8 @@
         android:layout_marginHorizontal="20dp"
         android:background="@drawable/bg_segment_container"
         android:padding="4dp"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvTitle">
 
         <RadioGroup
@@ -99,6 +99,22 @@
         </RadioGroup>
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/tvEmpty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No matches recorded. Schedule first match"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:fontFamily="@font/poppins_regular"
+        android:gravity="center"
+        android:visibility="gone"
+        android:layout_marginTop="24dp"
+        app:layout_constraintTop_toBottomOf="@id/segmentedContainer"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvMatches"
         android:layout_width="0dp"
@@ -108,10 +124,10 @@
         android:layout_marginTop="12dp"
         android:clipToPadding="false"
         android:paddingBottom="100dp"
-    app:layout_constraintTop_toBottomOf="@id/segmentedContainer"
-    app:layout_constraintBottom_toTopOf="@id/bottomBar"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/segmentedContainer"
+        app:layout_constraintBottom_toTopOf="@id/bottomBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
         android:id="@+id/bottomBar"
@@ -134,9 +150,7 @@
             android:textStyle="bold"
             android:textColor="@android:color/white"
             android:fontFamily="@font/unbounded"
-            android:background="@drawable/bg_btn_primary"/>
+            android:background="@drawable/bg_btn_primary" />
     </LinearLayout>
-
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add MatchModel and MatchesAdapter for displaying match cards
- implement MatchesFragment with sample data and filtering
- update Matches layout title and add empty state message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80574b6c0832ab8614748d266562d