### PR TITLE
Implement match editing screen

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
@@ -1,20 +1,36 @@
 package com.besosn.app.presentation.ui.matches
 
-import android.app.TimePickerDialog
+import android.content.Context
 import android.os.Bundle
+import android.text.InputFilter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.PopupWindow
+import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentMatchEditBinding
+import com.google.android.material.datepicker.MaterialDatePicker
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import org.json.JSONArray
+import org.json.JSONObject
 import java.util.Calendar
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class MatchEditFragment : Fragment() {
 
     private lateinit var binding: FragmentMatchEditBinding
+    private lateinit var popup: PopupWindow
+    private val teams = listOf("Barcelona", "Real Madrid", "Arsenal", "Chelsea")
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -26,39 +42,160 @@ class MatchEditFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Обработчик для нажатия на LinearLayout или Button
-        binding.timePickerContainer.setOnClickListener {
-            showTimePicker()
+        // time and date pickers
+        binding.timePickerContainer.setOnClickListener { showTimePicker() }
+        binding.datePickerContainer.setOnClickListener { showDatePicker() }
+
+        // dropdowns for teams
+        setupDropdown(binding.ddTeam, binding.tvTeam, binding.ivCategoryArrow, teams)
+        setupDropdown(binding.ddTeam2, binding.tvTeam2, binding.ivTeamAwayArrow, teams)
+
+        // limit goals input to two digits
+        val filter = InputFilter { source, start, end, dest, dstart, dend ->
+            val newValue = dest.toString().substring(0, dstart) +
+                    source.subSequence(start, end) + dest.toString().substring(dend)
+            if (newValue.length > 2) {
+                Toast.makeText(requireContext(),
+                    "Score value can’t be more than 99 goals",
+                    Toast.LENGTH_SHORT).show()
+                ""
+            } else null
         }
+        binding.etGoals.filters = arrayOf(filter)
+        binding.etAwayGoals.filters = arrayOf(filter)
+
+        binding.btnEdit.setOnClickListener { saveMatch() }
+        binding.btnCancel.setOnClickListener { findNavController().popBackStack() }
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
     }
 
+    private fun showDatePicker() {
+        val picker = MaterialDatePicker.Builder.datePicker()
+            .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
+            .build()
+        picker.addOnPositiveButtonClickListener { selection ->
+            val cal = Calendar.getInstance()
+            cal.timeInMillis = selection
+            val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            binding.tvDate.text = fmt.format(cal.time)
+        }
+        picker.show(parentFragmentManager, "date")
+    }
+
     private fun showTimePicker() {
         val calendar = Calendar.getInstance()
-        val hour = calendar.get(Calendar.HOUR_OF_DAY)
-        val minute = calendar.get(Calendar.MINUTE)
+        val picker = MaterialTimePicker.Builder()
+            .setTimeFormat(TimeFormat.CLOCK_12H)
+            .setHour(calendar.get(Calendar.HOUR_OF_DAY))
+            .setMinute(calendar.get(Calendar.MINUTE))
+            .build()
+        picker.addOnPositiveButtonClickListener {
+            val hour = picker.hour
+            val minute = picker.minute
+            val amPm = if (hour >= 12) "PM" else "AM"
+            val hour12 = if (hour % 12 == 0) 12 else hour % 12
+            binding.tvHour.text = String.format("%02d", hour12)
+            binding.tvMinute.text = String.format("%02d", minute)
+            binding.tvAmPm.text = amPm
+        }
+        picker.show(parentFragmentManager, "time")
+    }
 
-        val timePicker = TimePickerDialog(
-            requireContext(),
-            { _, selectedHour, selectedMinute ->
-                // Определяем AM/PM
-                val amPm = if (selectedHour >= 12) "PM" else "AM"
-                // Преобразуем в 12-часовой формат
-                val hour12 = if (selectedHour % 12 == 0) 12 else selectedHour % 12
+    private fun saveMatch() {
+        val homeTeam = binding.tvTeam.text.toString()
+        val awayTeam = binding.tvTeam2.text.toString()
+        val homeGoalsText = binding.etGoals.text.toString()
+        val awayGoalsText = binding.etAwayGoals.text.toString()
+        val city = binding.etCity.text.toString()
+        val date = binding.tvDate.text.toString()
+        val notes = binding.etNotes.text.toString()
 
-                // Устанавливаем значения в TextView
-                binding.tvHour.text = String.format("%02d", hour12)
-                binding.tvMinute.text = String.format("%02d", selectedMinute)
-                binding.tvAmPm.text = amPm
-            },
-            hour,
-            minute,
-            false // Используем 12-часовой формат
-        )
+        if (homeTeam == "Choose category" || awayTeam == "Choose category" ||
+            homeGoalsText.isBlank() || awayGoalsText.isBlank() ||
+            city.isBlank() || date == "Select date") {
+            Toast.makeText(requireContext(), "Fill all fields to add match", Toast.LENGTH_SHORT).show()
+            return
+        }
+        if (homeTeam == awayTeam) {
+            Toast.makeText(requireContext(), "One team does not play against each other", Toast.LENGTH_SHORT).show()
+            return
+        }
 
-        timePicker.show()
+        val prefs = requireContext().getSharedPreferences("matches_prefs", Context.MODE_PRIVATE)
+        val arr = JSONArray(prefs.getString("matches", "[]"))
+        val obj = JSONObject().apply {
+            put("homeTeam", homeTeam)
+            put("awayTeam", awayTeam)
+            put("homeGoals", homeGoalsText.toInt())
+            put("awayGoals", awayGoalsText.toInt())
+            put("notes", notes)
+            put("city", city)
+            put("date", date)
+            put("time", "${binding.tvHour.text}:${binding.tvMinute.text} ${binding.tvAmPm.text}")
+        }
+        arr.put(obj)
+        prefs.edit().putString("matches", arr.toString()).apply()
+
+        findNavController().popBackStack()
+    }
+
+    private fun setupDropdown(
+        anchorView: FrameLayout,
+        tv: TextView,
+        arrow: View,
+        list: List<String>
+    ) {
+        anchorView.setOnClickListener {
+            if (::popup.isInitialized && popup.isShowing) {
+                popup.dismiss()
+                return@setOnClickListener
+            }
+
+            val content = layoutInflater.inflate(R.layout.popup_dropdown, null, false)
+            val header = content.findViewById<TextView>(R.id.tvHeader)
+            val rv = content.findViewById<RecyclerView>(R.id.rv)
+
+            header.text = tv.text
+            rv.layoutManager = LinearLayoutManager(requireContext())
+            rv.adapter = object : RecyclerView.Adapter<VH>() {
+                override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+                    VH(LayoutInflater.from(parent.context)
+                        .inflate(R.layout.item_dropdown_row, parent, false))
+
+                override fun getItemCount() = list.size
+                override fun onBindViewHolder(holder: VH, pos: Int) {
+                    holder.txt.text = list[pos]
+                    holder.divider.visibility = if (pos == list.lastIndex) View.GONE else View.VISIBLE
+                    holder.itemView.setOnClickListener {
+                        tv.text = list[pos]
+                        tv.setTextColor(android.graphics.Color.WHITE)
+                        popup.dismiss()
+                    }
+                }
+            }
+
+            popup = PopupWindow(
+                content,
+                anchorView.width,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                true
+            ).apply {
+                isOutsideTouchable = true
+                setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
+                elevation = 16f
+                setOnDismissListener { arrow.rotation = 0f }
+            }
+
+            arrow.animate().rotation(180f).setDuration(120).start()
+            popup.showAsDropDown(anchorView, 0, 8)
+        }
+    }
+
+    private class VH(view: View) : RecyclerView.ViewHolder(view) {
+        val txt: TextView = view.findViewById(R.id.tvText)
+        val divider: View = view.findViewById(R.id.divider)
     }
 }

--- a/app/src/main/res/layout/fragment_match_edit.xml
+++ b/app/src/main/res/layout/fragment_match_edit.xml
@@ -321,6 +321,42 @@
 
                 </LinearLayout>
 
+            <!-- Match date picker -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="@font/poppins_regular"
+                    android:text="Match date"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp" />
+
+                <LinearLayout
+                    android:id="@+id/datePickerContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_input_team"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="18dp">
+
+                    <TextView
+                        android:id="@+id/tvDate"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Select date"
+                        android:textColor="#B3FFFFFF"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- Time picker -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -370,7 +406,6 @@
                         android:layout_height="wrap_content"
                         android:text="00"
                         android:fontFamily="@font/outfit_regular"
-
                         android:textSize="36sp"
                         android:textColor="#73FFFFFF"
                         android:padding="8dp"/>
@@ -380,7 +415,6 @@
                         android:layout_height="wrap_content"
                         android:text=":"
                         android:fontFamily="@font/inter_regular"
-
                         android:textSize="20sp"
                         android:textColor="#FFFFFF"
                         android:padding="8dp"/>
@@ -391,14 +425,43 @@
                         android:layout_height="wrap_content"
                         android:text="PM"
                         android:fontFamily="@font/outfit_regular"
-
                         android:textSize="36sp"
                         android:textColor="#FFFFFF"
                         android:padding="8dp"/>
 
                 </LinearLayout>
 
-                </LinearLayout>
+            </LinearLayout>
+
+            <!-- City input -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="@font/poppins_regular"
+                    android:text="City"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp" />
+
+                <EditText
+                    android:id="@+id/etCity"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:background="@drawable/bg_input_team"
+                    android:fontFamily="@font/poppins_regular"
+                    android:hint="Enter city"
+                    android:paddingHorizontal="16dp"
+                    android:textColor="@android:color/white"
+                    android:textColorHint="#72FFFFFF"
+                    android:textSize="16sp" />
+
+            </LinearLayout>
 
 
 
@@ -461,12 +524,11 @@
                         android:layout_height="wrap_content" />
 
                     <ImageButton
-                        android:id="@+id/btnDelete"
+                        android:id="@+id/btnCancel"
                         android:layout_width="56dp"
                         android:layout_height="56dp"
-
                         android:background="@drawable/btn_delete_gradient"
-                        android:contentDescription="Delete"
+                        android:contentDescription="Cancel"
                         android:scaleType="centerInside"
                         android:src="@drawable/trash_icon" />
                 </LinearLayout>


### PR DESCRIPTION
## Summary
- add material date/time pickers and city field to match editor
- validate and persist date, city, and score inputs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81d12b52c832a9de1eb74ed9a7f3f