### PR TITLE
Implement match editing screen

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
@@ -1,64 +1,307 @@
 package com.besosn.app.presentation.ui.matches
 
+import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.text.InputFilter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.PopupWindow
+import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.room.Room
 import com.besosn.app.R
+import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentMatchEditBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Locale
 
 class MatchEditFragment : Fragment() {
 
-    private lateinit var binding: FragmentMatchEditBinding
+    private var _binding: FragmentMatchEditBinding? = null
+    private val binding get() = _binding!!
+
+    private var popup: PopupWindow? = null
+    private val teamOptions = mutableListOf("Barcelona", "Real Madrid", "Arsenal", "Chelsea")
+    private val matchCalendar: Calendar = Calendar.getInstance()
+    private var dateSelected = false
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentMatchEditBinding.inflate(inflater, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentMatchEditBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Обработчик для нажатия на LinearLayout или Button
-        binding.timePickerContainer.setOnClickListener {
-            showTimePicker()
+        loadTeamOptions()
+
+        updateTimeViews(
+            matchCalendar.get(Calendar.HOUR_OF_DAY),
+            matchCalendar.get(Calendar.MINUTE),
+        )
+
+        val scoreTooHighMessage = getString(R.string.match_edit_score_too_high)
+        val goalsFilter = InputFilter { source, start, end, dest, dstart, dend ->
+            val newValue = dest.toString().substring(0, dstart) +
+                source.subSequence(start, end) + dest.toString().substring(dend)
+            if (newValue.length > 2) {
+                Toast.makeText(requireContext(), scoreTooHighMessage, Toast.LENGTH_SHORT).show()
+                ""
+            } else {
+                null
+            }
         }
+
+        binding.etGoals.filters = arrayOf(goalsFilter)
+        binding.etAwayGoals.filters = arrayOf(goalsFilter)
+
+        binding.timePickerContainer.setOnClickListener { showTimePicker() }
+        binding.datePickerContainer.setOnClickListener { showDatePicker() }
+
+        setupDropdown(binding.ddTeam, binding.tvTeam, binding.ivCategoryArrow, teamOptions)
+        setupDropdown(binding.ddTeam2, binding.tvTeam2, binding.ivTeamAwayArrow, teamOptions)
+
+        binding.btnEdit.setOnClickListener { saveMatch() }
+        binding.btnCancel.setOnClickListener { findNavController().popBackStack() }
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
     }
 
-    private fun showTimePicker() {
-        val calendar = Calendar.getInstance()
-        val hour = calendar.get(Calendar.HOUR_OF_DAY)
-        val minute = calendar.get(Calendar.MINUTE)
+    private fun loadTeamOptions() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val context = requireContext().applicationContext
+            val db = Room.databaseBuilder(context, AppDatabase::class.java, "app_db")
+                .fallbackToDestructiveMigration()
+                .build()
 
-        val timePicker = TimePickerDialog(
+            val names = withContext(Dispatchers.IO) {
+                try {
+                    db.teamDao().getTeams().map { it.name }
+                } catch (_: Exception) {
+                    emptyList()
+                } finally {
+                    db.close()
+                }
+            }
+
+            if (names.isNotEmpty()) {
+                teamOptions.clear()
+                teamOptions.addAll(names)
+            }
+        }
+    }
+
+    private fun showDatePicker() {
+        DatePickerDialog(
             requireContext(),
-            { _, selectedHour, selectedMinute ->
-                // Определяем AM/PM
-                val amPm = if (selectedHour >= 12) "PM" else "AM"
-                // Преобразуем в 12-часовой формат
-                val hour12 = if (selectedHour % 12 == 0) 12 else selectedHour % 12
+            { _, year, month, dayOfMonth ->
+                matchCalendar.set(Calendar.YEAR, year)
+                matchCalendar.set(Calendar.MONTH, month)
+                matchCalendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+                dateSelected = true
 
-                // Устанавливаем значения в TextView
-                binding.tvHour.text = String.format("%02d", hour12)
-                binding.tvMinute.text = String.format("%02d", selectedMinute)
-                binding.tvAmPm.text = amPm
+                val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                binding.tvDate.text = fmt.format(matchCalendar.time)
+                binding.tvDate.setTextColor(Color.WHITE)
             },
-            hour,
-            minute,
-            false // Используем 12-часовой формат
-        )
+            matchCalendar.get(Calendar.YEAR),
+            matchCalendar.get(Calendar.MONTH),
+            matchCalendar.get(Calendar.DAY_OF_MONTH),
+        ).show()
+    }
 
-        timePicker.show()
+    private fun showTimePicker() {
+        TimePickerDialog(
+            requireContext(),
+            { _, hourOfDay, minute ->
+                matchCalendar.set(Calendar.HOUR_OF_DAY, hourOfDay)
+                matchCalendar.set(Calendar.MINUTE, minute)
+                matchCalendar.set(Calendar.SECOND, 0)
+                matchCalendar.set(Calendar.MILLISECOND, 0)
+                updateTimeViews(hourOfDay, minute)
+            },
+            matchCalendar.get(Calendar.HOUR_OF_DAY),
+            matchCalendar.get(Calendar.MINUTE),
+            false,
+        ).show()
+    }
+
+    private fun updateTimeViews(hourOfDay: Int, minute: Int) {
+        val amPm = if (hourOfDay >= 12) "PM" else "AM"
+        val hour12 = if (hourOfDay % 12 == 0) 12 else hourOfDay % 12
+        binding.tvHour.text = String.format(Locale.getDefault(), "%02d", hour12)
+        binding.tvMinute.text = String.format(Locale.getDefault(), "%02d", minute)
+        binding.tvAmPm.text = amPm
+    }
+
+    private fun saveMatch() {
+        val teamPlaceholder = getString(R.string.match_edit_choose_team)
+        val datePlaceholder = getString(R.string.match_edit_select_date)
+        val homeTeam = binding.tvTeam.text.toString()
+        val awayTeam = binding.tvTeam2.text.toString()
+        val homeGoalsText = binding.etGoals.text.toString()
+        val awayGoalsText = binding.etAwayGoals.text.toString()
+        val city = binding.etCity.text.toString().trim()
+        val notes = binding.etNotes.text.toString().trim()
+        val dateText = binding.tvDate.text.toString()
+
+        val homeGoals = homeGoalsText.toIntOrNull()
+        val awayGoals = awayGoalsText.toIntOrNull()
+
+        if (homeTeam == teamPlaceholder || awayTeam == teamPlaceholder ||
+            homeGoals == null || awayGoals == null ||
+            city.isBlank() || !dateSelected || dateText == datePlaceholder
+        ) {
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.match_edit_fill_all_fields),
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+
+        if (homeTeam == awayTeam) {
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.match_edit_same_team_error),
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+
+        if (homeGoals > 99 || awayGoals > 99) {
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.match_edit_score_too_high),
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+
+        val prefs = requireContext().getSharedPreferences("matches_prefs", Context.MODE_PRIVATE)
+        val arr = JSONArray(prefs.getString("matches", "[]"))
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val timeFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
+        val obj = JSONObject().apply {
+            put("homeTeam", homeTeam)
+            put("awayTeam", awayTeam)
+            put("homeGoals", homeGoals)
+            put("awayGoals", awayGoals)
+            put("notes", notes)
+            put("city", city)
+            put("date", dateFormat.format(matchCalendar.time))
+            put("time", timeFormat.format(matchCalendar.time))
+            put("timestamp", matchCalendar.timeInMillis)
+        }
+        arr.put(obj)
+        prefs.edit().putString("matches", arr.toString()).apply()
+
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.match_edit_saved_message),
+            Toast.LENGTH_SHORT,
+        ).show()
+
+        findNavController().popBackStack()
+    }
+
+    private fun setupDropdown(
+        anchorView: FrameLayout,
+        tv: TextView,
+        arrow: View,
+        list: List<String>,
+    ) {
+        anchorView.setOnClickListener {
+            popup?.let {
+                if (it.isShowing) {
+                    it.dismiss()
+                    return@setOnClickListener
+                }
+            }
+
+            val content = layoutInflater.inflate(R.layout.popup_dropdown, null, false)
+            val header = content.findViewById<TextView>(R.id.tvHeader)
+            val rv = content.findViewById<RecyclerView>(R.id.rv)
+
+            header.text = tv.text
+            rv.layoutManager = LinearLayoutManager(requireContext())
+
+            val popupWindow = PopupWindow(
+                content,
+                anchorView.width,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                true,
+            ).apply {
+                isOutsideTouchable = true
+                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                elevation = 16f
+                setOnDismissListener {
+                    arrow.rotation = 0f
+                    if (popup === this) {
+                        popup = null
+                    }
+                }
+            }
+
+            rv.adapter = object : RecyclerView.Adapter<DropdownViewHolder>() {
+                override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DropdownViewHolder {
+                    val itemView = LayoutInflater.from(parent.context)
+                        .inflate(R.layout.item_dropdown_row, parent, false)
+                    return DropdownViewHolder(itemView)
+                }
+
+                override fun getItemCount() = list.size
+
+                override fun onBindViewHolder(holder: DropdownViewHolder, position: Int) {
+                    holder.txt.text = list[position]
+                    holder.divider.visibility = if (position == list.lastIndex) View.GONE else View.VISIBLE
+                    holder.itemView.setOnClickListener {
+                        tv.text = list[position]
+                        tv.setTextColor(Color.WHITE)
+                        popupWindow.dismiss()
+                    }
+                }
+            }
+
+            popup = popupWindow
+            arrow.animate().rotation(180f).setDuration(120).start()
+            popupWindow.showAsDropDown(anchorView, 0, 8)
+        }
+    }
+
+    override fun onDestroyView() {
+        popup?.dismiss()
+        popup = null
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private class DropdownViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val txt: TextView = view.findViewById(R.id.tvText)
+        val divider: View = view.findViewById(R.id.divider)
     }
 }

--- a/app/src/main/res/layout/fragment_match_edit.xml
+++ b/app/src/main/res/layout/fragment_match_edit.xml
@@ -113,7 +113,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:gravity="center_vertical"
-                            android:text="Choose category"
+                            android:text="@string/match_edit_choose_team"
                             android:textColor="#B3FFFFFF"
                             android:textSize="16sp" />
 
@@ -178,7 +178,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
                                 android:gravity="center_vertical"
-                                android:text="Choose category"
+                                android:text="@string/match_edit_choose_team"
                                 android:textColor="#B3FFFFFF"
                                 android:textSize="16sp" />
 
@@ -321,6 +321,7 @@
 
                 </LinearLayout>
 
+            <!-- Match date picker -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -332,7 +333,42 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"
                     android:fontFamily="@font/poppins_regular"
-                    android:text="Departure Time"
+                    android:text="Match date"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp" />
+
+                <LinearLayout
+                    android:id="@+id/datePickerContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_input_team"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="18dp">
+
+                    <TextView
+                        android:id="@+id/tvDate"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/match_edit_select_date"
+                        android:textColor="#B3FFFFFF"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- Time picker -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="@font/poppins_regular"
+                    android:text="@string/match_edit_time_label"
                     android:textColor="@android:color/white"
                     android:textSize="16sp" />
                 <!-- layout/timer_picker_view.xml -->
@@ -370,7 +406,6 @@
                         android:layout_height="wrap_content"
                         android:text="00"
                         android:fontFamily="@font/outfit_regular"
-
                         android:textSize="36sp"
                         android:textColor="#73FFFFFF"
                         android:padding="8dp"/>
@@ -380,7 +415,6 @@
                         android:layout_height="wrap_content"
                         android:text=":"
                         android:fontFamily="@font/inter_regular"
-
                         android:textSize="20sp"
                         android:textColor="#FFFFFF"
                         android:padding="8dp"/>
@@ -391,14 +425,43 @@
                         android:layout_height="wrap_content"
                         android:text="PM"
                         android:fontFamily="@font/outfit_regular"
-
                         android:textSize="36sp"
                         android:textColor="#FFFFFF"
                         android:padding="8dp"/>
 
                 </LinearLayout>
 
-                </LinearLayout>
+            </LinearLayout>
+
+            <!-- City input -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:fontFamily="@font/poppins_regular"
+                    android:text="City"
+                    android:textColor="@android:color/white"
+                    android:textSize="16sp" />
+
+                <EditText
+                    android:id="@+id/etCity"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:background="@drawable/bg_input_team"
+                    android:fontFamily="@font/poppins_regular"
+                    android:hint="Enter city"
+                    android:paddingHorizontal="16dp"
+                    android:textColor="@android:color/white"
+                    android:textColorHint="#72FFFFFF"
+                    android:textSize="16sp" />
+
+            </LinearLayout>
 
 
 
@@ -413,7 +476,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:fontFamily="@font/unbounded"
-                    android:text="About inventory"
+                    android:text="@string/match_edit_notes_label"
                     android:textAllCaps="true"
                     android:textColor="#FC4F08"
                     android:textSize="25sp"
@@ -460,15 +523,17 @@
                         android:layout_width="12dp"
                         android:layout_height="wrap_content" />
 
-                    <ImageButton
-                        android:id="@+id/btnDelete"
-                        android:layout_width="56dp"
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/btnCancel"
+                        android:layout_width="0dp"
                         android:layout_height="56dp"
-
-                        android:background="@drawable/btn_delete_gradient"
-                        android:contentDescription="Delete"
-                        android:scaleType="centerInside"
-                        android:src="@drawable/trash_icon" />
+                        android:layout_weight="1"
+                        android:background="@drawable/bg_input_team"
+                        android:fontFamily="@font/unbounded"
+                        android:text="@string/match_edit_cancel"
+                        android:textColor="@android:color/white"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,14 @@
     <string name="fill_all_fields">Fill all fields to save team data.</string>
     <string name="select_position">Select position</string>
 
+    <string name="match_edit_choose_team">Choose team</string>
+    <string name="match_edit_select_date">Select date</string>
+    <string name="match_edit_fill_all_fields">Fill all fields to add match</string>
+    <string name="match_edit_same_team_error">One team does not play against each other</string>
+    <string name="match_edit_score_too_high">Score value can’t be more than 99 goals</string>
+    <string name="match_edit_saved_message">Match saved</string>
+    <string name="match_edit_cancel">Cancel</string>
+    <string name="match_edit_notes_label">Notes</string>
+    <string name="match_edit_time_label">Match time</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- replace Material date/time pickers with platform dialogs to avoid the missing drawable crash
- validate and persist date, city, and score inputs
- load available teams, fix the dropdown view holder collision, and refresh the match editor layout strings/buttons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81d12b52c832a9de1eb74ed9a7f3f