### PR TITLE
Load saved matches and handle missing team image permissions

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchEditFragment.kt
@@ -176,14 +176,35 @@ class MatchEditFragment : Fragment() {
 
         val homeGoals = homeGoalsText.toIntOrNull()
         val awayGoals = awayGoalsText.toIntOrNull()
+        val hasHomeGoalsInput = homeGoalsText.isNotBlank()
+        val hasAwayGoalsInput = awayGoalsText.isNotBlank()
 
         if (homeTeam == teamPlaceholder || awayTeam == teamPlaceholder ||
-            homeGoals == null || awayGoals == null ||
             city.isBlank() || !dateSelected || dateText == datePlaceholder
         ) {
             Toast.makeText(
                 requireContext(),
                 getString(R.string.match_edit_fill_all_fields),
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+
+        if (hasHomeGoalsInput != hasAwayGoalsInput) {
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.match_edit_enter_both_scores),
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+
+        val scoresProvided = hasHomeGoalsInput && hasAwayGoalsInput
+
+        if (scoresProvided && (homeGoals == null || awayGoals == null)) {
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.match_edit_enter_valid_scores),
                 Toast.LENGTH_SHORT,
             ).show()
             return
@@ -198,7 +219,7 @@ class MatchEditFragment : Fragment() {
             return
         }
 
-        if (homeGoals > 99 || awayGoals > 99) {
+        if ((homeGoals != null && homeGoals > 99) || (awayGoals != null && awayGoals > 99)) {
             Toast.makeText(
                 requireContext(),
                 getString(R.string.match_edit_score_too_high),
@@ -215,8 +236,10 @@ class MatchEditFragment : Fragment() {
         val obj = JSONObject().apply {
             put("homeTeam", homeTeam)
             put("awayTeam", awayTeam)
-            put("homeGoals", homeGoals)
-            put("awayGoals", awayGoals)
+            if (scoresProvided) {
+                homeGoals?.let { put("homeGoals", it) }
+                awayGoals?.let { put("awayGoals", it) }
+            }
             put("notes", notes)
             put("city", city)
             put("date", dateFormat.format(matchCalendar.time))

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
@@ -1,14 +1,20 @@
 package com.besosn.app.presentation.ui.matches
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
+import androidx.annotation.DrawableRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentMatchesBinding
+import org.json.JSONArray
+import org.json.JSONException
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Locale
 
 class MatchesFragment : Fragment(R.layout.fragment_matches) {
 
@@ -17,6 +23,7 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
 
     private lateinit var adapter: MatchesAdapter
     private val matches = mutableListOf<MatchModel>()
+    private var currentFilter: MatchFilter = MatchFilter.ALL
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -28,8 +35,8 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
         binding.rvMatches.layoutManager = LinearLayoutManager(requireContext())
         binding.rvMatches.adapter = adapter
 
-        loadMatches()
         setupFilters()
+        loadMatches()
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {
@@ -40,13 +47,26 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (_binding != null) {
+            loadMatches()
+        }
+    }
+
     private fun loadMatches() {
         matches.clear()
+        matches.addAll(getDefaultMatches())
+        matches.addAll(loadSavedMatches())
+        applyFilter(currentFilter)
+    }
+
+    private fun getDefaultMatches(): List<MatchModel> {
         val now = Calendar.getInstance()
         val past = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -1) }
         val future = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, 3) }
 
-        matches.add(
+        return listOf(
             MatchModel(
                 id = 1,
                 homeTeam = "Barcelona",
@@ -56,9 +76,7 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
                 date = past.timeInMillis,
                 homeScore = 1,
                 awayScore = 2
-            )
-        )
-        matches.add(
+            ),
             MatchModel(
                 id = 2,
                 homeTeam = "Arsenal",
@@ -66,9 +84,48 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
                 homeIconRes = R.drawable.vdgdsgfds,
                 awayIconRes = R.drawable.jkljfsjfls,
                 date = future.timeInMillis
-            )
+            ),
         )
-        applyFilter(MatchFilter.ALL)
+    }
+
+    private fun loadSavedMatches(): List<MatchModel> {
+        val prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getString(PREFS_KEY_MATCHES, null) ?: return emptyList()
+
+        return try {
+            val array = JSONArray(raw)
+            val result = mutableListOf<MatchModel>()
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val homeTeam = obj.optString("homeTeam")
+                val awayTeam = obj.optString("awayTeam")
+                if (homeTeam.isBlank() || awayTeam.isBlank()) continue
+
+                val timestamp = obj.optLong("timestamp", -1L)
+                val dateMillis = if (timestamp > 0L) {
+                    timestamp
+                } else {
+                    parseDateTime(obj.optString("date"), obj.optString("time")) ?: continue
+                }
+
+                val homeScore = (obj.opt("homeGoals") as? Number)?.toInt()
+                val awayScore = (obj.opt("awayGoals") as? Number)?.toInt()
+
+                result += MatchModel(
+                    id = SAVED_MATCH_ID_OFFSET + i,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    homeIconRes = resolveTeamIcon(homeTeam),
+                    awayIconRes = resolveTeamIcon(awayTeam),
+                    date = dateMillis,
+                    homeScore = homeScore,
+                    awayScore = awayScore,
+                )
+            }
+            result
+        } catch (_: JSONException) {
+            emptyList()
+        }
     }
 
     private fun setupFilters() {
@@ -78,6 +135,7 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
                 R.id.tabFinished -> MatchFilter.FINISHED
                 else -> MatchFilter.ALL
             }
+            currentFilter = filter
             applyFilter(filter)
         }
     }
@@ -98,6 +156,33 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun parseDateTime(date: String?, time: String?): Long? {
+        if (date.isNullOrBlank() || time.isNullOrBlank()) return null
+        return try {
+            val format = SimpleDateFormat("yyyy-MM-dd hh:mm a", Locale.getDefault())
+            format.parse("$date $time")?.time
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    @DrawableRes
+    private fun resolveTeamIcon(teamName: String): Int {
+        return when (teamName.trim().lowercase(Locale.getDefault())) {
+            "barcelona" -> R.drawable.vdgdsgfds
+            "real madrid" -> R.drawable.jkljfsjfls
+            "arsenal" -> R.drawable.vdgdsgfds
+            "chelsea" -> R.drawable.jkljfsjfls
+            else -> R.drawable.ic_users
+        }
+    }
+
+    private companion object {
+        private const val SAVED_MATCH_ID_OFFSET = 1000
+        private const val PREFS_NAME = "matches_prefs"
+        private const val PREFS_KEY_MATCHES = "matches"
     }
 }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayersAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/PlayersAdapter.kt
@@ -1,8 +1,9 @@
 package com.besosn.app.presentation.ui.teams
 
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.net.Uri
+import java.io.FileNotFoundException
 import androidx.recyclerview.widget.RecyclerView
 import com.besosn.app.databinding.ItemPlayerBinding
 
@@ -29,11 +30,26 @@ class PlayersAdapter(private val items: List<PlayerModel>) :
             binding.tvPlayerName.text = player.fullName
             binding.tvNumber.text = player.number.toString()
             binding.tvPosition.text = player.position
-            if (player.photoUri != null) {
-                binding.imgPlayer.setImageURI(Uri.parse(player.photoUri))
-            } else {
-                binding.imgPlayer.setImageResource(com.besosn.app.R.drawable.ic_users)
+            val photoUri = player.photoUri
+            if (!photoUri.isNullOrBlank()) {
+                val parsed = runCatching { Uri.parse(photoUri) }.getOrNull()
+                if (parsed != null) {
+                    try {
+                        binding.imgPlayer.setImageURI(parsed)
+                        if (binding.imgPlayer.drawable != null) {
+                            return
+                        }
+                    } catch (_: SecurityException) {
+                        // The app no longer has permission to read the selected photo.
+                    } catch (_: FileNotFoundException) {
+                        // Image removed from the device, so we show the fallback icon instead.
+                    } catch (_: IllegalArgumentException) {
+                        // Invalid URI format, fall back to the default icon below.
+                    }
+                }
             }
+
+            binding.imgPlayer.setImageResource(com.besosn.app.R.drawable.ic_users)
         }
     }
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamIconExtensions.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamIconExtensions.kt
@@ -3,14 +3,28 @@ package com.besosn.app.presentation.ui.teams
 import android.content.res.Resources
 import android.net.Uri
 import android.widget.ImageView
+import java.io.FileNotFoundException
 import androidx.annotation.DrawableRes
 import com.besosn.app.R
 
 internal fun ImageView.loadTeamImage(team: TeamModel, @DrawableRes fallback: Int = R.drawable.ic_users) {
     val iconUri = team.iconUri
     if (!iconUri.isNullOrBlank()) {
-        setImageURI(Uri.parse(iconUri))
-        return
+        val parsed = runCatching { Uri.parse(iconUri) }.getOrNull()
+        if (parsed != null) {
+            try {
+                setImageURI(parsed)
+                if (drawable != null) {
+                    return
+                }
+            } catch (_: SecurityException) {
+                // We have lost URI read permissions (for example when using the Photo Picker).
+            } catch (_: FileNotFoundException) {
+                // The picked image is no longer available on the device.
+            } catch (_: IllegalArgumentException) {
+                // Invalid URI value – fall back to the default icon below.
+            }
+        }
     }
 
     setImageResource(resolveTeamIconRes(context.resources, team.iconRes, fallback))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="match_edit_select_date">Select date</string>
     <string name="match_edit_fill_all_fields">Fill all fields to add match</string>
     <string name="match_edit_same_team_error">One team does not play against each other</string>
+    <string name="match_edit_enter_both_scores">Enter both team scores to finish the match</string>
+    <string name="match_edit_enter_valid_scores">Enter valid numeric scores for each team</string>
     <string name="match_edit_score_too_high">Score value can’t be more than 99 goals</string>
     <string name="match_edit_saved_message">Match saved</string>
     <string name="match_edit_cancel">Cancel</string>


### PR DESCRIPTION
## Summary
- reload the matches list from shared preferences whenever the matches screen becomes active
- keep the active filter when refreshing data and supply fallback icons for stored teams
- retain the sample matches while appending any saved entries and keep the empty-state handling intact
- allow matches to be saved without scores so upcoming games remain scheduled
- guard team and player image binding against missing URI permissions so the teams screen falls back to default icons instead of crashing

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c928d10250832a823a1b024804ee6b