### PR TITLE
Adjust home layout dimensions for small screens

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -7,7 +7,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="250dp"
+        android:layout_height="@dimen/home_background_fade_height"
         android:layout_gravity="bottom"
         android:background="@drawable/bg_black_fade"/>
 
@@ -20,12 +20,12 @@
         android:id="@+id/tvTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30dp"
+        android:layout_marginTop="@dimen/home_title_margin_top"
         android:fontFamily="@font/unbounded"
         android:text="BESOSN"
-        android:layout_marginStart="30dp"
+        android:layout_marginStart="@dimen/home_title_margin_start"
         android:textColor="#FC4F08"
-        android:textSize="48sp"
+        android:textSize="@dimen/home_title_text_size"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -33,7 +33,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="15dp"
+            android:layout_marginBottom="@dimen/home_cards_container_margin_bottom"
             android:orientation="vertical"
             app:layout_constraintBottom_toTopOf="@+id/bottomButtons"
             app:layout_constraintEnd_toEndOf="parent"
@@ -44,12 +44,12 @@
                 android:id="@+id/cardTeams"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="24dp"
-                android:layout_marginTop="16dp"
+                android:layout_marginHorizontal="@dimen/home_card_margin_horizontal"
+                android:layout_marginTop="@dimen/home_card_margin_top"
                 android:background="@drawable/bg_card_gradient"
                 android:clipToOutline="true"
                 android:orientation="vertical"
-                android:padding="16dp"
+                android:padding="@dimen/home_card_padding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tvTitle">
@@ -62,8 +62,8 @@
                     android:orientation="horizontal">
 
                     <ImageView
-                        android:layout_width="60dp"
-                        android:layout_height="60dp"
+                        android:layout_width="@dimen/home_card_icon_size"
+                        android:layout_height="@dimen/home_card_icon_size"
                         android:src="@drawable/ic_users" />
 
                     <View
@@ -72,8 +72,8 @@
                         android:layout_weight="1" />
 
                     <ImageView
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="@dimen/home_card_arrow_icon_size"
+                        android:layout_height="@dimen/home_card_arrow_icon_size"
                         android:layout_gravity="top"
                         android:src="@drawable/ic_arrow_ne" />
                 </LinearLayout>
@@ -82,22 +82,22 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
+                    android:layout_marginTop="@dimen/home_card_title_margin_top"
                     android:fontFamily="@font/unbounded"
                     android:text="Teams"
                     android:textColor="@android:color/white"
-                    android:textSize="40sp"
+                    android:textSize="@dimen/home_card_title_text_size"
                     android:textStyle="bold" />
 
                 <!-- Подзаголовок -->
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
+                    android:layout_marginTop="@dimen/home_card_subtitle_margin_top"
                     android:fontFamily="@font/prompt_regular"
                     android:text="You have no teams yet"
                     android:textColor="#E6FFFFFF"
-                    android:textSize="14sp" />
+                    android:textSize="@dimen/home_card_subtitle_text_size" />
             </LinearLayout>
 
             <!-- Карточка Inventory -->
@@ -105,12 +105,12 @@
                 android:id="@+id/cardInventory"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="24dp"
-                android:layout_marginTop="14dp"
+                android:layout_marginHorizontal="@dimen/home_card_margin_horizontal"
+                android:layout_marginTop="@dimen/home_inventory_card_margin_top"
                 android:background="@drawable/bg_card_gradient"
                 android:clipToOutline="true"
                 android:orientation="vertical"
-                android:padding="20dp"
+                android:padding="@dimen/home_inventory_card_padding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cardTeams">
@@ -123,8 +123,8 @@
                     android:orientation="horizontal">
 
                     <ImageView
-                        android:layout_width="60dp"
-                        android:layout_height="60dp"
+                        android:layout_width="@dimen/home_card_icon_size"
+                        android:layout_height="@dimen/home_card_icon_size"
                         android:src="@drawable/backpack_ic" />
 
                     <View
@@ -133,8 +133,8 @@
                         android:layout_weight="1" />
 
                     <ImageView
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="@dimen/home_card_arrow_icon_size"
+                        android:layout_height="@dimen/home_card_arrow_icon_size"
                         android:layout_gravity="top"
                         android:src="@drawable/ic_arrow_ne" />
                 </LinearLayout>
@@ -143,22 +143,22 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
+                    android:layout_marginTop="@dimen/home_card_title_margin_top"
                     android:fontFamily="@font/unbounded"
                     android:text="Inventory"
                     android:textColor="@android:color/white"
-                    android:textSize="40sp"
+                    android:textSize="@dimen/home_card_title_text_size"
                     android:textStyle="bold" />
 
                 <!-- Подзаголовок -->
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
+                    android:layout_marginTop="@dimen/home_card_subtitle_margin_top"
                     android:fontFamily="@font/prompt_regular"
                     android:text="You have no teams yet"
                     android:textColor="#E6FFFFFF"
-                    android:textSize="14sp" />
+                    android:textSize="@dimen/home_card_subtitle_text_size" />
             </LinearLayout>
 
             <!-- Карточка Matches -->
@@ -166,28 +166,28 @@
                 android:id="@+id/cardMatches"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="24dp"
-                android:layout_marginTop="16dp"
+                android:layout_marginHorizontal="@dimen/home_card_margin_horizontal"
+                android:layout_marginTop="@dimen/home_card_margin_top"
                 android:background="@drawable/bg_card_gradient"
                 android:clipToOutline="true"
                 android:gravity="center|start"
                 android:orientation="horizontal"
-                android:padding="16dp"
+                android:padding="@dimen/home_matches_card_padding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cardInventory">
 
                 <ImageView
-                    android:layout_width="55dp"
-                    android:layout_height="55dp"
-                    android:layout_marginRight="10dp"
+                    android:layout_width="@dimen/home_matches_icon_size"
+                    android:layout_height="@dimen/home_matches_icon_size"
+                    android:layout_marginEnd="@dimen/home_matches_icon_margin_end"
                     android:src="@drawable/soccer_ball" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:paddingVertical="10dp">
+                    android:paddingVertical="@dimen/home_matches_content_padding_vertical">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -201,12 +201,12 @@
                             android:fontFamily="@font/unbounded"
                             android:text="Matches"
                             android:textColor="@android:color/white"
-                            android:textSize="30sp"
+                            android:textSize="@dimen/home_matches_title_text_size"
                             android:textStyle="bold" />
 
                         <ImageView
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="@dimen/home_card_arrow_icon_size"
+                            android:layout_height="@dimen/home_card_arrow_icon_size"
                             android:layout_gravity="top"
                             android:src="@drawable/ic_arrow_ne" />
 
@@ -216,9 +216,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="16 matches"
-                        android:layout_marginTop="5dp"
+                        android:layout_marginTop="@dimen/home_matches_count_margin_top"
                         android:textColor="@android:color/white"
-                        android:textSize="14sp" />
+                        android:textSize="@dimen/home_matches_count_text_size" />
                 </LinearLayout>
 
             </LinearLayout>
@@ -230,8 +230,8 @@
         android:id="@+id/bottomButtons"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="24dp"
-        android:layout_marginBottom="24dp"
+        android:layout_marginHorizontal="@dimen/home_bottom_buttons_margin_horizontal"
+        android:layout_marginBottom="@dimen/home_bottom_buttons_margin_bottom"
         android:gravity="center"
         android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -242,56 +242,56 @@
         <LinearLayout
             android:id="@+id/btnArticles"
             android:layout_width="0dp"
-            android:layout_height="55dp"
+            android:layout_height="@dimen/home_bottom_buttons_height"
             android:layout_weight="1"
             android:background="@drawable/bg_outline_orange"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:paddingHorizontal="16dp">
+            android:paddingHorizontal="@dimen/home_bottom_buttons_padding_horizontal">
 
             <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
+                android:layout_width="@dimen/home_bottom_buttons_icon_size"
+                android:layout_height="@dimen/home_bottom_buttons_icon_size"
                 android:src="@drawable/vector"
-                android:layout_marginEnd="12dp"/>
+                android:layout_marginEnd="@dimen/home_bottom_buttons_icon_margin_end_articles"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Articles"
-                android:textSize="18dp"
+                android:textSize="@dimen/home_bottom_buttons_text_size"
                 android:textColor="#FC4F08"
                 android:textStyle="bold"
                 android:fontFamily="@font/unbounded"/>
         </LinearLayout>
 
         <View
-            android:layout_width="12dp"
+            android:layout_width="@dimen/home_bottom_buttons_divider_width"
             android:layout_height="0dp"/>
 
         <!-- Settings -->
         <LinearLayout
             android:id="@+id/btnSettings"
             android:layout_width="0dp"
-            android:layout_height="55dp"
+            android:layout_height="@dimen/home_bottom_buttons_height"
             android:layout_weight="1"
             android:background="@drawable/bg_outline_orange"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:paddingHorizontal="16dp">
+            android:paddingHorizontal="@dimen/home_bottom_buttons_padding_horizontal">
 
             <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
+                android:layout_width="@dimen/home_bottom_buttons_icon_size"
+                android:layout_height="@dimen/home_bottom_buttons_icon_size"
                 android:src="@drawable/sliders"
-                android:layout_marginEnd="8dp"/>
+                android:layout_marginEnd="@dimen/home_bottom_buttons_icon_margin_end_settings"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Settings"
                 android:textColor="#FC4F08"
-                android:textSize="18dp"
+                android:textSize="@dimen/home_bottom_buttons_text_size"
                 android:textStyle="bold"
                 android:fontFamily="@font/unbounded"/>
         </LinearLayout>

--- a/app/src/main/res/values-small/dimens.xml
+++ b/app/src/main/res/values-small/dimens.xml
@@ -1,0 +1,34 @@
+<resources>
+    <dimen name="home_background_fade_height">200dp</dimen>
+    <dimen name="home_title_margin_start">24dp</dimen>
+    <dimen name="home_title_margin_top">24dp</dimen>
+    <dimen name="home_title_text_size">40sp</dimen>
+    <dimen name="home_cards_container_margin_bottom">10dp</dimen>
+    <dimen name="home_card_margin_horizontal">16dp</dimen>
+    <dimen name="home_card_margin_top">12dp</dimen>
+    <dimen name="home_inventory_card_margin_top">10dp</dimen>
+    <dimen name="home_card_padding">12dp</dimen>
+    <dimen name="home_inventory_card_padding">14dp</dimen>
+    <dimen name="home_card_icon_size">48dp</dimen>
+    <dimen name="home_card_arrow_icon_size">28dp</dimen>
+    <dimen name="home_card_title_margin_top">8dp</dimen>
+    <dimen name="home_card_title_text_size">30sp</dimen>
+    <dimen name="home_card_subtitle_margin_top">4dp</dimen>
+    <dimen name="home_card_subtitle_text_size">12sp</dimen>
+    <dimen name="home_matches_card_padding">12dp</dimen>
+    <dimen name="home_matches_icon_size">44dp</dimen>
+    <dimen name="home_matches_icon_margin_end">8dp</dimen>
+    <dimen name="home_matches_content_padding_vertical">8dp</dimen>
+    <dimen name="home_matches_title_text_size">24sp</dimen>
+    <dimen name="home_matches_count_margin_top">4dp</dimen>
+    <dimen name="home_matches_count_text_size">12sp</dimen>
+    <dimen name="home_bottom_buttons_margin_horizontal">16dp</dimen>
+    <dimen name="home_bottom_buttons_margin_bottom">16dp</dimen>
+    <dimen name="home_bottom_buttons_height">48dp</dimen>
+    <dimen name="home_bottom_buttons_padding_horizontal">12dp</dimen>
+    <dimen name="home_bottom_buttons_icon_size">16dp</dimen>
+    <dimen name="home_bottom_buttons_icon_margin_end_articles">8dp</dimen>
+    <dimen name="home_bottom_buttons_icon_margin_end_settings">6dp</dimen>
+    <dimen name="home_bottom_buttons_text_size">16sp</dimen>
+    <dimen name="home_bottom_buttons_divider_width">8dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,34 @@
+<resources>
+    <dimen name="home_background_fade_height">250dp</dimen>
+    <dimen name="home_title_margin_start">30dp</dimen>
+    <dimen name="home_title_margin_top">30dp</dimen>
+    <dimen name="home_title_text_size">48sp</dimen>
+    <dimen name="home_cards_container_margin_bottom">15dp</dimen>
+    <dimen name="home_card_margin_horizontal">24dp</dimen>
+    <dimen name="home_card_margin_top">16dp</dimen>
+    <dimen name="home_inventory_card_margin_top">14dp</dimen>
+    <dimen name="home_card_padding">16dp</dimen>
+    <dimen name="home_inventory_card_padding">20dp</dimen>
+    <dimen name="home_card_icon_size">60dp</dimen>
+    <dimen name="home_card_arrow_icon_size">35dp</dimen>
+    <dimen name="home_card_title_margin_top">12dp</dimen>
+    <dimen name="home_card_title_text_size">40sp</dimen>
+    <dimen name="home_card_subtitle_margin_top">5dp</dimen>
+    <dimen name="home_card_subtitle_text_size">14sp</dimen>
+    <dimen name="home_matches_card_padding">16dp</dimen>
+    <dimen name="home_matches_icon_size">55dp</dimen>
+    <dimen name="home_matches_icon_margin_end">10dp</dimen>
+    <dimen name="home_matches_content_padding_vertical">10dp</dimen>
+    <dimen name="home_matches_title_text_size">30sp</dimen>
+    <dimen name="home_matches_count_margin_top">5dp</dimen>
+    <dimen name="home_matches_count_text_size">14sp</dimen>
+    <dimen name="home_bottom_buttons_margin_horizontal">24dp</dimen>
+    <dimen name="home_bottom_buttons_margin_bottom">24dp</dimen>
+    <dimen name="home_bottom_buttons_height">55dp</dimen>
+    <dimen name="home_bottom_buttons_padding_horizontal">16dp</dimen>
+    <dimen name="home_bottom_buttons_icon_size">20dp</dimen>
+    <dimen name="home_bottom_buttons_icon_margin_end_articles">12dp</dimen>
+    <dimen name="home_bottom_buttons_icon_margin_end_settings">8dp</dimen>
+    <dimen name="home_bottom_buttons_text_size">18sp</dimen>
+    <dimen name="home_bottom_buttons_divider_width">12dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- move the home fragment layout's hardcoded sizes into dedicated dimension resources
- add a small-screen dimension override to shrink typography, spacing, and icons for compact devices

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9404a0e60832abab3f0759c4d7edf