### PR TITLE
Implement settings actions and data clearing

### DIFF
--- a/app/src/main/java/com/besosn/app/data/local/db/dao/InventoryDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/InventoryDao.kt
@@ -14,5 +14,8 @@ interface InventoryDao {
 
     @Delete
     suspend fun deleteItem(item: InventoryEntity)
+
+    @Query("DELETE FROM inventory")
+    suspend fun deleteAllItems()
 }
 

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/MatchDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/MatchDao.kt
@@ -14,5 +14,8 @@ interface MatchDao {
 
     @Delete
     suspend fun deleteMatch(match: MatchEntity)
+
+    @Query("DELETE FROM matches")
+    suspend fun deleteAllMatches()
 }
 

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/PlayerDao.kt
@@ -22,5 +22,8 @@ interface PlayerDao {
 
     @Update
     suspend fun updatePlayer(player: PlayerEntity)
+
+    @Query("DELETE FROM players")
+    suspend fun deleteAllPlayers()
 }
 

--- a/app/src/main/java/com/besosn/app/data/local/db/dao/TeamDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/TeamDao.kt
@@ -15,5 +15,8 @@ interface TeamDao {
 
     @Update
     suspend fun updateTeam(team: TeamEntity)
+
+    @Query("DELETE FROM teams")
+    suspend fun deleteAllTeams()
 }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/settings/SettingsFragment.kt
@@ -1,12 +1,24 @@
 package com.besosn.app.presentation.ui.settings
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.addCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.room.Room
 import com.besosn.app.R
+import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentSettingsBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingsFragment : Fragment(R.layout.fragment_settings) {
 
@@ -18,16 +30,111 @@ class SettingsFragment : Fragment(R.layout.fragment_settings) {
         _binding = FragmentSettingsBinding.bind(view)
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
-//        binding.btnPrivacyPolicy.setOnClickListener {
-//            findNavController().navigate(R.id.action_settingsFragment_to_privacyPolicyFragment)
-//        }
+        binding.shareAdd.setOnClickListener { shareApp() }
+        binding.rateUs.setOnClickListener { rateApp() }
+        binding.privacyPolicy.setOnClickListener {
+            findNavController().navigate(R.id.action_settingsFragment_to_privacyPolicyFragment)
+        }
+        binding.termsOfUse.setOnClickListener {
+            findNavController().navigate(R.id.action_settingsFragment_to_termsOfUseFragment)
+        }
+        binding.btnArticles.setOnClickListener { confirmClearData() }
+
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun shareApp() {
+        val packageName = requireContext().packageName
+        val shareText = getString(R.string.settings_share_text, packageName)
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, shareText)
+        }
+
+        runCatching {
+            startActivity(Intent.createChooser(intent, getString(R.string.settings_share_chooser_title)))
+        }.onFailure {
+            if (isAdded) {
+                Toast.makeText(requireContext(), R.string.settings_share_error, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun rateApp() {
+        val packageName = requireContext().packageName
+        val playUri = Uri.parse("market://details?id=$packageName")
+        val marketIntent = Intent(Intent.ACTION_VIEW, playUri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY or Intent.FLAG_ACTIVITY_NEW_DOCUMENT or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        }
+
+        try {
+            startActivity(marketIntent)
+        } catch (_: ActivityNotFoundException) {
+            val webUri = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+            runCatching { startActivity(Intent(Intent.ACTION_VIEW, webUri)) }
+                .onFailure {
+                    if (isAdded) {
+                        Toast.makeText(requireContext(), R.string.settings_rate_error, Toast.LENGTH_SHORT).show()
+                    }
+                }
+        }
+    }
+
+    private fun confirmClearData() {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.settings_clear_data_title)
+            .setMessage(R.string.settings_clear_data_message)
+            .setPositiveButton(R.string.settings_clear_data_confirm) { _, _ -> clearAppData() }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun clearAppData() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val context = requireContext().applicationContext
+            val success = withContext(Dispatchers.IO) {
+                runCatching {
+                    val db = Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
+                        .fallbackToDestructiveMigration()
+                        .build()
+
+                    try {
+                        db.playerDao().deleteAllPlayers()
+                        db.teamDao().deleteAllTeams()
+                        db.inventoryDao().deleteAllItems()
+                        db.matchDao().deleteAllMatches()
+                    } finally {
+                        db.close()
+                    }
+
+                    context.getSharedPreferences(PREFS_NAME_MATCHES, Context.MODE_PRIVATE)
+                        .edit()
+                        .remove(PREFS_KEY_MATCHES)
+                        .apply()
+                }.isSuccess
+            }
+
+            if (!isAdded) return@launch
+
+            val messageRes = if (success) {
+                R.string.settings_clear_data_success
+            } else {
+                R.string.settings_clear_data_error
+            }
+            Toast.makeText(requireContext(), messageRes, Toast.LENGTH_SHORT).show()
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val DATABASE_NAME = "app_db"
+        private const val PREFS_NAME_MATCHES = "matches_prefs"
+        private const val PREFS_KEY_MATCHES = "matches"
     }
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/settings/TermsOfUseFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/settings/TermsOfUseFragment.kt
@@ -1,0 +1,30 @@
+package com.besosn.app.presentation.ui.settings
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.addCallback
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.besosn.app.R
+import com.besosn.app.databinding.FragmentTermsOfUseBinding
+
+class TermsOfUseFragment : Fragment(R.layout.fragment_terms_of_use) {
+
+    private var _binding: FragmentTermsOfUseBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentTermsOfUseBinding.bind(view)
+
+        binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            findNavController().popBackStack()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_terms_of_use.xml
+++ b/app/src/main/res/layout/fragment_terms_of_use.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:gravity="center_horizontal">
+
+    <ImageView
+        android:id="@+id/btnBack"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:src="@drawable/back" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/settings_terms_title"
+        android:textSize="24sp" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/navgraph.xml
+++ b/app/src/main/res/navigation/navgraph.xml
@@ -149,10 +149,18 @@
         <action
             android:id="@+id/action_settingsFragment_to_privacyPolicyFragment"
             app:destination="@id/privacyPolicyFragment" />
+        <action
+            android:id="@+id/action_settingsFragment_to_termsOfUseFragment"
+            app:destination="@id/termsOfUseFragment" />
     </fragment>
 
     <fragment
         android:id="@+id/privacyPolicyFragment"
         android:name="com.besosn.app.presentation.ui.settings.PrivacyPolicyFragment"
         android:label="PrivacyPolicyFragment" />
+
+    <fragment
+        android:id="@+id/termsOfUseFragment"
+        android:name="com.besosn.app.presentation.ui.settings.TermsOfUseFragment"
+        android:label="TermsOfUseFragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,17 @@
     <string name="match_edit_notes_label">Notes</string>
     <string name="match_edit_time_label">Match time</string>
 
+    <string name="settings_share_text">Look at wonderful app for soccer team and inventory management: http://play.google.com/store/apps/details?id=%1$s</string>
+    <string name="settings_share_chooser_title">Share the app via</string>
+    <string name="settings_share_error">No application available to share content.</string>
+    <string name="settings_rate_error">Unable to open Google Play Store.</string>
+    <string name="settings_clear_data_title">Clear data</string>
+    <string name="settings_clear_data_message">This will remove all saved teams, players, inventory items, and matches. Continue?</string>
+    <string name="settings_clear_data_confirm">Clear</string>
+    <string name="settings_clear_data_success">App data cleared.</string>
+    <string name="settings_clear_data_error">Unable to clear app data.</string>
+    <string name="settings_terms_title">Terms of Use</string>
+
     <string name="article_back_content_description">Go back</string>
     <string name="article_cover_content_description">Article cover image</string>
     <string name="article_not_found">Unable to load this article.</string>


### PR DESCRIPTION
## Summary
- add sharing, rating, privacy, and terms interactions to the settings screen
- provide DAO helpers and Settings logic to clear stored team, player, inventory, and match data
- create a blank Terms of Use fragment, layout, navigation entry, and supporting strings

## Testing
- ./gradlew lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c963ad8dfc832a812ac854af159bef