### PR TITLE
Show live match count on home screen

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/home/HomeFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentHomeBinding
+import com.besosn.app.presentation.ui.matches.MatchesLocalDataSource
 
 class HomeFragment : Fragment(R.layout.fragment_home) {
 
@@ -31,10 +32,30 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         binding.btnSettings.setOnClickListener {
             findNavController().navigate(R.id.action_homeFragment_to_settingsFragment)
         }
+
+        updateMatchesCount()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (_binding != null) {
+            updateMatchesCount()
+        }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun updateMatchesCount() {
+        val context = context ?: return
+        val totalMatches = MatchesLocalDataSource.loadMatches(context).size
+        val countText = resources.getQuantityString(
+            R.plurals.home_matches_count,
+            totalMatches,
+            totalMatches,
+        )
+        binding.matchesCount.text = countText
     }
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
@@ -1,20 +1,13 @@
 package com.besosn.app.presentation.ui.matches
 
-import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
-import androidx.annotation.DrawableRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentMatchesBinding
-import org.json.JSONArray
-import org.json.JSONException
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Locale
 
 class MatchesFragment : Fragment(R.layout.fragment_matches) {
 
@@ -56,76 +49,8 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
 
     private fun loadMatches() {
         matches.clear()
-        matches.addAll(getDefaultMatches())
-        matches.addAll(loadSavedMatches())
+        matches.addAll(MatchesLocalDataSource.loadMatches(requireContext()))
         applyFilter(currentFilter)
-    }
-
-    private fun getDefaultMatches(): List<MatchModel> {
-        val now = Calendar.getInstance()
-        val past = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -1) }
-        val future = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, 3) }
-
-        return listOf(
-            MatchModel(
-                id = 1,
-                homeTeam = "Barcelona",
-                awayTeam = "Real Madrid",
-                homeIconRes = R.drawable.vdgdsgfds,
-                awayIconRes = R.drawable.jkljfsjfls,
-                date = past.timeInMillis,
-                homeScore = 1,
-                awayScore = 2
-            ),
-            MatchModel(
-                id = 2,
-                homeTeam = "Arsenal",
-                awayTeam = "Chelsea",
-                homeIconRes = R.drawable.vdgdsgfds,
-                awayIconRes = R.drawable.jkljfsjfls,
-                date = future.timeInMillis
-            ),
-        )
-    }
-
-    private fun loadSavedMatches(): List<MatchModel> {
-        val prefs = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val raw = prefs.getString(PREFS_KEY_MATCHES, null) ?: return emptyList()
-
-        return try {
-            val array = JSONArray(raw)
-            val result = mutableListOf<MatchModel>()
-            for (i in 0 until array.length()) {
-                val obj = array.optJSONObject(i) ?: continue
-                val homeTeam = obj.optString("homeTeam")
-                val awayTeam = obj.optString("awayTeam")
-                if (homeTeam.isBlank() || awayTeam.isBlank()) continue
-
-                val timestamp = obj.optLong("timestamp", -1L)
-                val dateMillis = if (timestamp > 0L) {
-                    timestamp
-                } else {
-                    parseDateTime(obj.optString("date"), obj.optString("time")) ?: continue
-                }
-
-                val homeScore = (obj.opt("homeGoals") as? Number)?.toInt()
-                val awayScore = (obj.opt("awayGoals") as? Number)?.toInt()
-
-                result += MatchModel(
-                    id = SAVED_MATCH_ID_OFFSET + i,
-                    homeTeam = homeTeam,
-                    awayTeam = awayTeam,
-                    homeIconRes = resolveTeamIcon(homeTeam),
-                    awayIconRes = resolveTeamIcon(awayTeam),
-                    date = dateMillis,
-                    homeScore = homeScore,
-                    awayScore = awayScore,
-                )
-            }
-            result
-        } catch (_: JSONException) {
-            emptyList()
-        }
     }
 
     private fun setupFilters() {
@@ -156,33 +81,6 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    private fun parseDateTime(date: String?, time: String?): Long? {
-        if (date.isNullOrBlank() || time.isNullOrBlank()) return null
-        return try {
-            val format = SimpleDateFormat("yyyy-MM-dd hh:mm a", Locale.getDefault())
-            format.parse("$date $time")?.time
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    @DrawableRes
-    private fun resolveTeamIcon(teamName: String): Int {
-        return when (teamName.trim().lowercase(Locale.getDefault())) {
-            "barcelona" -> R.drawable.vdgdsgfds
-            "real madrid" -> R.drawable.jkljfsjfls
-            "arsenal" -> R.drawable.vdgdsgfds
-            "chelsea" -> R.drawable.jkljfsjfls
-            else -> R.drawable.ic_users
-        }
-    }
-
-    private companion object {
-        private const val SAVED_MATCH_ID_OFFSET = 1000
-        private const val PREFS_NAME = "matches_prefs"
-        private const val PREFS_KEY_MATCHES = "matches"
     }
 }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
@@ -1,0 +1,116 @@
+package com.besosn.app.presentation.ui.matches
+
+import android.content.Context
+import androidx.annotation.DrawableRes
+import com.besosn.app.R
+import org.json.JSONArray
+import org.json.JSONException
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+/**
+ * Provides access to match data that is stored locally in SharedPreferences
+ * together with the predefined demo matches that ship with the app.
+ */
+object MatchesLocalDataSource {
+
+    fun loadMatches(context: Context): List<MatchModel> {
+        val matches = mutableListOf<MatchModel>()
+        matches += getDefaultMatches()
+        matches += loadSavedMatches(context)
+        return matches
+    }
+
+    internal fun loadSavedMatches(context: Context): List<MatchModel> {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getString(PREFS_KEY_MATCHES, null) ?: return emptyList()
+
+        return try {
+            val array = JSONArray(raw)
+            val result = mutableListOf<MatchModel>()
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val homeTeam = obj.optString("homeTeam")
+                val awayTeam = obj.optString("awayTeam")
+                if (homeTeam.isBlank() || awayTeam.isBlank()) continue
+
+                val timestamp = obj.optLong("timestamp", -1L)
+                val dateMillis = if (timestamp > 0L) {
+                    timestamp
+                } else {
+                    parseDateTime(obj.optString("date"), obj.optString("time")) ?: continue
+                }
+
+                val homeScore = (obj.opt("homeGoals") as? Number)?.toInt()
+                val awayScore = (obj.opt("awayGoals") as? Number)?.toInt()
+
+                result += MatchModel(
+                    id = SAVED_MATCH_ID_OFFSET + i,
+                    homeTeam = homeTeam,
+                    awayTeam = awayTeam,
+                    homeIconRes = resolveTeamIcon(homeTeam),
+                    awayIconRes = resolveTeamIcon(awayTeam),
+                    date = dateMillis,
+                    homeScore = homeScore,
+                    awayScore = awayScore,
+                )
+            }
+            result
+        } catch (_: JSONException) {
+            emptyList()
+        }
+    }
+
+    private fun getDefaultMatches(): List<MatchModel> {
+        val now = Calendar.getInstance()
+        val past = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -1) }
+        val future = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, 3) }
+
+        return listOf(
+            MatchModel(
+                id = 1,
+                homeTeam = "Barcelona",
+                awayTeam = "Real Madrid",
+                homeIconRes = R.drawable.vdgdsgfds,
+                awayIconRes = R.drawable.jkljfsjfls,
+                date = past.timeInMillis,
+                homeScore = 1,
+                awayScore = 2,
+            ),
+            MatchModel(
+                id = 2,
+                homeTeam = "Arsenal",
+                awayTeam = "Chelsea",
+                homeIconRes = R.drawable.vdgdsgfds,
+                awayIconRes = R.drawable.jkljfsjfls,
+                date = future.timeInMillis,
+            ),
+        )
+    }
+
+    private fun parseDateTime(date: String?, time: String?): Long? {
+        if (date.isNullOrBlank() || time.isNullOrBlank()) return null
+        return try {
+            val format = SimpleDateFormat("yyyy-MM-dd hh:mm a", Locale.getDefault())
+            format.parse("$date $time")?.time
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    @DrawableRes
+    private fun resolveTeamIcon(teamName: String): Int {
+        return when (teamName.trim().lowercase(Locale.getDefault())) {
+            "barcelona" -> R.drawable.vdgdsgfds
+            "real madrid" -> R.drawable.jkljfsjfls
+            "arsenal" -> R.drawable.vdgdsgfds
+            "chelsea" -> R.drawable.jkljfsjfls
+            else -> R.drawable.ic_users
+        }
+    }
+
+    private const val SAVED_MATCH_ID_OFFSET = 1000
+    private const val PREFS_NAME = "matches_prefs"
+    private const val PREFS_KEY_MATCHES = "matches"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,9 @@
     <string name="article_cover_content_description">Article cover image</string>
     <string name="article_not_found">Unable to load this article.</string>
 
+    <plurals name="home_matches_count">
+        <item quantity="one">%d match</item>
+        <item quantity="other">%d matches</item>
+    </plurals>
+
 </resources>


### PR DESCRIPTION
## Summary
- extract local match loading logic into a reusable MatchesLocalDataSource
- update MatchesFragment to use the shared data source
- display the actual number of matches on the Home screen using a pluralized string

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c968f1f014832a8d34af1e5d6c92ee