### PR TITLE
Add match photo upload and Room persistence

### DIFF
--- a/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/AppDatabase.kt
@@ -21,7 +21,7 @@ import com.besosn.app.data.local.db.dao.TeamDao
         InventoryEntity::class,
         ArticleEntity::class
     ],
-    version = 5
+    version = 6
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun teamDao(): TeamDao

--- a/app/src/main/java/com/besosn/app/data/model/MatchEntity.kt
+++ b/app/src/main/java/com/besosn/app/data/model/MatchEntity.kt
@@ -6,8 +6,14 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "matches")
 data class MatchEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
-    val homeTeamId: Int,
-    val awayTeamId: Int,
-    val date: Long
+    val homeTeamName: String,
+    val awayTeamName: String,
+    val date: Long,
+    val city: String,
+    val notes: String,
+    val homeGoals: Int?,
+    val awayGoals: Int?,
+    val homePhotoUri: String?,
+    val awayPhotoUri: String?,
 )
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
@@ -10,11 +10,15 @@ data class MatchModel(
     val id: Int = 0,
     val homeTeam: String,
     val awayTeam: String,
-    @DrawableRes val homeIconRes: Int,
-    @DrawableRes val awayIconRes: Int,
+    @DrawableRes val homeIconRes: Int = 0,
+    @DrawableRes val awayIconRes: Int = 0,
+    val homeIconUri: String? = null,
+    val awayIconUri: String? = null,
     val date: Long,
     val homeScore: Int? = null,
-    val awayScore: Int? = null
+    val awayScore: Int? = null,
+    val city: String? = null,
+    val notes: String? = null,
 ) : Serializable {
     val isFinished: Boolean get() = homeScore != null && awayScore != null
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
@@ -1,9 +1,14 @@
 package com.besosn.app.presentation.ui.matches
 
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
 import androidx.recyclerview.widget.RecyclerView
+import com.besosn.app.R
 import com.besosn.app.databinding.MatchItemBinding
+import java.io.FileNotFoundException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -38,8 +43,8 @@ class MatchesAdapter(
             binding.tvMatchDate.text = dateFormat.format(Date(match.date))
             binding.tvTeam1.text = match.homeTeam
             binding.tvTeam2.text = match.awayTeam
-            binding.imgTeamLogo.setImageResource(match.homeIconRes)
-            binding.imgTeamLogo2.setImageResource(match.awayIconRes)
+            binding.imgTeamLogo.loadMatchIcon(match.homeIconRes, match.homeIconUri)
+            binding.imgTeamLogo2.loadMatchIcon(match.awayIconRes, match.awayIconUri)
             binding.tvMatchScore.text = if (match.isFinished) {
                 "${match.homeScore}:${match.awayScore}"
             } else {
@@ -47,5 +52,31 @@ class MatchesAdapter(
             }
             binding.root.setOnClickListener { onItemClick(match) }
         }
+    }
+}
+
+private fun ImageView.loadMatchIcon(@DrawableRes iconRes: Int, iconUri: String?) {
+    if (!iconUri.isNullOrBlank()) {
+        val parsed = runCatching { Uri.parse(iconUri) }.getOrNull()
+        if (parsed != null) {
+            try {
+                setImageURI(parsed)
+                if (drawable != null) {
+                    return
+                }
+            } catch (_: SecurityException) {
+                // Ignore and fall back to resource icon
+            } catch (_: FileNotFoundException) {
+                // Ignore and fall back to resource icon
+            } catch (_: IllegalArgumentException) {
+                // Ignore and fall back to resource icon
+            }
+        }
+    }
+
+    if (iconRes != 0) {
+        setImageResource(iconRes)
+    } else {
+        setImageResource(R.drawable.ic_users)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="match_edit_enter_valid_scores">Enter valid numeric scores for each team</string>
     <string name="match_edit_score_too_high">Score value can’t be more than 99 goals</string>
     <string name="match_edit_saved_message">Match saved</string>
+    <string name="match_edit_save_failed">Failed to save match. Please try again.</string>
     <string name="match_edit_cancel">Cancel</string>
     <string name="match_edit_notes_label">Notes</string>
     <string name="match_edit_time_label">Match time</string>


### PR DESCRIPTION
## Summary
- add photo pickers to the match editor and remember the chosen images
- persist saved matches through Room with the extra match details
- surface Room backed matches on the list screen and render custom icons when available

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96945b4a0832aa20f87b31ea6b13c