### PR TITLE
Implement match detail image loading

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.besosn.app.presentation.ui.matches
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
@@ -7,11 +8,27 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentMatchDetailBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class MatchDetailFragment : Fragment(R.layout.fragment_match_detail) {
 
     private var _binding: FragmentMatchDetailBinding? = null
     private val binding get() = _binding!!
+    private var match: MatchModel? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        match = arguments?.let { bundle ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                bundle.getSerializable(ARG_MATCH, MatchModel::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                (bundle.getSerializable(ARG_MATCH) as? MatchModel)
+            }
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -24,10 +41,52 @@ class MatchDetailFragment : Fragment(R.layout.fragment_match_detail) {
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+
+        match?.let { bindMatch(it) }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun bindMatch(match: MatchModel) {
+        binding.firstTeam.text = match.homeTeam
+        binding.secondTeam.text = match.awayTeam
+
+        binding.team1Logo.loadMatchIcon(match.homeIconRes, match.homeIconUri)
+        binding.team2Logo.loadMatchIcon(match.awayIconRes, match.awayIconUri)
+
+        if (match.isFinished) {
+            binding.team1Score.text = match.homeScore?.toString()
+                ?: getString(R.string.match_detail_score_placeholder)
+            binding.team2Score.text = match.awayScore?.toString()
+                ?: getString(R.string.match_detail_score_placeholder)
+        } else {
+            val placeholder = getString(R.string.match_detail_score_placeholder)
+            binding.team1Score.text = placeholder
+            binding.team2Score.text = placeholder
+        }
+
+        val city = match.city?.takeIf { it.isNotBlank() }
+            ?: getString(R.string.match_detail_unknown_city)
+        binding.tvCityValue.text = city
+
+        val date = Date(match.date)
+        val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+        val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+        binding.tvFoundedValue.text = getString(
+            R.string.match_detail_date_time,
+            dateFormat.format(date),
+            timeFormat.format(date),
+        )
+
+        val notes = match.notes?.takeIf { it.isNotBlank() }
+            ?: getString(R.string.match_detail_no_notes)
+        binding.tvNotes.text = notes
+    }
+
+    companion object {
+        const val ARG_MATCH = "arg_match"
     }
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchIconExtensions.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchIconExtensions.kt
@@ -1,0 +1,42 @@
+package com.besosn.app.presentation.ui.matches
+
+import android.net.Uri
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import com.besosn.app.R
+import java.io.FileNotFoundException
+
+internal fun ImageView.loadMatchIcon(
+    @DrawableRes iconRes: Int,
+    iconUri: String?,
+    @DrawableRes fallback: Int = R.drawable.jkljfsjfls,
+) {
+    if (!iconUri.isNullOrBlank()) {
+        val parsed = runCatching { Uri.parse(iconUri) }.getOrNull()
+        if (parsed != null) {
+            try {
+                setImageURI(parsed)
+                if (drawable != null) {
+                    return
+                }
+            } catch (_: SecurityException) {
+                // Ignore and fall back to resource icon
+            } catch (_: FileNotFoundException) {
+                // Ignore and fall back to resource icon
+            } catch (_: IllegalArgumentException) {
+                // Ignore and fall back to resource icon
+            }
+        }
+    }
+
+    if (iconRes != 0) {
+        try {
+            setImageResource(iconRes)
+            return
+        } catch (_: Exception) {
+            // Fall through and use fallback icon
+        }
+    }
+
+    setImageResource(fallback)
+}

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesAdapter.kt
@@ -1,14 +1,9 @@
 package com.besosn.app.presentation.ui.matches
 
-import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
-import androidx.annotation.DrawableRes
 import androidx.recyclerview.widget.RecyclerView
-import com.besosn.app.R
 import com.besosn.app.databinding.MatchItemBinding
-import java.io.FileNotFoundException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -52,31 +47,5 @@ class MatchesAdapter(
             }
             binding.root.setOnClickListener { onItemClick(match) }
         }
-    }
-}
-
-private fun ImageView.loadMatchIcon(@DrawableRes iconRes: Int, iconUri: String?) {
-    if (!iconUri.isNullOrBlank()) {
-        val parsed = runCatching { Uri.parse(iconUri) }.getOrNull()
-        if (parsed != null) {
-            try {
-                setImageURI(parsed)
-                if (drawable != null) {
-                    return
-                }
-            } catch (_: SecurityException) {
-                // Ignore and fall back to resource icon
-            } catch (_: FileNotFoundException) {
-                // Ignore and fall back to resource icon
-            } catch (_: IllegalArgumentException) {
-                // Ignore and fall back to resource icon
-            }
-        }
-    }
-
-    if (iconRes != 0) {
-        setImageResource(iconRes)
-    } else {
-        setImageResource(R.drawable.jkljfsjfls)
     }
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
@@ -3,6 +3,7 @@ package com.besosn.app.presentation.ui.matches
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -10,7 +11,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.room.Room
 import com.besosn.app.R
 import com.besosn.app.data.local.db.AppDatabase
-import com.besosn.app.data.model.MatchEntity
 import com.besosn.app.databinding.FragmentMatchesBinding
 import kotlinx.coroutines.launch
 
@@ -30,8 +30,9 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentMatchesBinding.bind(view)
 
-        adapter = MatchesAdapter(mutableListOf()) {
-            findNavController().navigate(R.id.action_matchesFragment_to_matchDetailFragment)
+        adapter = MatchesAdapter(mutableListOf()) { match ->
+            val args = bundleOf(MatchDetailFragment.ARG_MATCH to match)
+            findNavController().navigate(R.id.action_matchesFragment_to_matchDetailFragment, args)
         }
         binding.rvMatches.layoutManager = LinearLayoutManager(requireContext())
         binding.rvMatches.adapter = adapter

--- a/app/src/main/res/layout/fragment_match_detail.xml
+++ b/app/src/main/res/layout/fragment_match_detail.xml
@@ -318,12 +318,13 @@
                     android:textAllCaps="true"/>
 
                 <TextView
+                    android:id="@+id/tvNotes"
                     android:layout_width="match_parent"
-                    android:textSize="16sp"
+                    android:layout_height="wrap_content"
                     android:fontFamily="@font/poppins_regular"
-                    android:textColor="#A2FFFFFF"
                     android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-                    android:layout_height="wrap_content"/>
+                    android:textColor="#A2FFFFFF"
+                    android:textSize="16sp" />
 
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="match_edit_cancel">Cancel</string>
     <string name="match_edit_notes_label">Notes</string>
     <string name="match_edit_time_label">Match time</string>
+    <string name="match_detail_score_placeholder">-</string>
+    <string name="match_detail_unknown_city">Unknown city</string>
+    <string name="match_detail_no_notes">No additional notes for this match.</string>
+    <string name="match_detail_date_time">%1$s at %2$s</string>
 
     <string name="settings_share_text">Look at wonderful app for soccer team and inventory management: http://play.google.com/store/apps/details?id=%1$s</string>
     <string name="settings_share_chooser_title">Share the app via</string>


### PR DESCRIPTION
## Summary
- add a reusable match icon loader that resolves URIs and drawable fallbacks
- pass the selected match into MatchDetailFragment and bind its teams, scores, city, date, and notes
- expose the notes view for updates and add string resources for detail placeholders

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d6ef9fd8832aabf15fec9ed7f98c