### PR TITLE
Show saved matches from database in schedule list

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
@@ -100,7 +100,7 @@ object MatchesLocalDataSource {
     }
 
     @DrawableRes
-    private fun resolveTeamIcon(teamName: String): Int {
+    internal fun resolveTeamIcon(teamName: String): Int {
         return when (teamName.trim().lowercase(Locale.getDefault())) {
             "barcelona" -> R.drawable.vdgdsgfds
             "real madrid" -> R.drawable.jkljfsjfls


### PR DESCRIPTION
## Summary
- observe the matches Room database and merge saved entries with the locally defined demo matches
- map MatchEntity rows to MatchModel items so custom icons, photos, and metadata display correctly in the schedule
- expose the shared team icon resolver so both the fragment and the data source reuse the same lookup

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae75c2190832ab32dae2213615826