### PR TITLE
Add toasts for limits and enforce single-line team fields

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsEditFragment.kt
@@ -77,14 +77,14 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
         binding.etFoundedYear.doOnTextChanged { text, _, _, _ ->
             if (skipFoundedYearWatcher) return@doOnTextChanged
             val length = text?.length ?: 0
-            if (length == 4 && !foundedYearWarningShown) {
+            if (length == MAX_FOUNDED_YEAR_DIGITS && !foundedYearWarningShown) {
                 Toast.makeText(
                     requireContext(),
                     getString(R.string.team_edit_founded_year_limit_warning),
                     Toast.LENGTH_SHORT,
                 ).show()
                 foundedYearWarningShown = true
-            } else if (length < 4) {
+            } else if (length < MAX_FOUNDED_YEAR_DIGITS) {
                 foundedYearWarningShown = false
             }
         }
@@ -110,7 +110,7 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
             skipFoundedYearWatcher = true
             binding.etFoundedYear.setText(team.foundedYear.toString())
             skipFoundedYearWatcher = false
-            foundedYearWarningShown = binding.etFoundedYear.length() == 4
+            foundedYearWarningShown = binding.etFoundedYear.length() == MAX_FOUNDED_YEAR_DIGITS
             binding.etNotes.setText(team.notes)
             selectedIconUri = team.iconUri
             binding.imageView2.loadTeamImage(team)
@@ -202,6 +202,32 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
         val ivPhoto = dialogView.findViewById<ImageView>(R.id.ivAddPhoto)
         val btnAdd = dialogView.findViewById<AppCompatButton>(R.id.btnAddPlayer)
         val btnCancel = dialogView.findViewById<AppCompatImageButton>(R.id.btnCancel)
+
+        var numberLimitWarningShown = false
+        val numberLimitFilter = InputFilter { source, start, end, dest, dstart, dend ->
+            val newValue = dest.toString().substring(0, dstart) +
+                source.subSequence(start, end) + dest.toString().substring(dend)
+            if (newValue.length > MAX_PLAYER_NUMBER_DIGITS) {
+                if (!numberLimitWarningShown) {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.team_edit_player_number_limit_warning),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                    numberLimitWarningShown = true
+                }
+                ""
+            } else {
+                null
+            }
+        }
+
+        etNumber.filters = arrayOf(numberLimitFilter)
+        etNumber.doOnTextChanged { text, _, _, _ ->
+            if ((text?.length ?: 0) < MAX_PLAYER_NUMBER_DIGITS) {
+                numberLimitWarningShown = false
+            }
+        }
 
         var popup: PopupWindow? = null
         val positions = resources.getStringArray(R.array.player_positions)
@@ -295,5 +321,10 @@ class TeamsEditFragment : Fragment(R.layout.fragment_teams_edit) {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private companion object {
+        const val MAX_FOUNDED_YEAR_DIGITS = 4
+        const val MAX_PLAYER_NUMBER_DIGITS = 2
     }
 }

--- a/app/src/main/res/layout/dialog_add_player.xml
+++ b/app/src/main/res/layout/dialog_add_player.xml
@@ -70,6 +70,7 @@
                     android:maxLines="1"
                     android:fontFamily="@font/poppins_regular"
                     android:textSize="16sp"
+                    android:ellipsize="end"
                     android:singleLine="true"/>
             </LinearLayout>
         </LinearLayout>
@@ -159,7 +160,7 @@
                     android:fontFamily="@font/poppins_regular"
                     android:textSize="16sp"
                     android:inputType="number"
-                    android:maxLength="2"
+                    android:ellipsize="end"
                     android:singleLine="true"/>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_match_edit.xml
+++ b/app/src/main/res/layout/fragment_match_edit.xml
@@ -120,7 +120,10 @@
                             android:gravity="center_vertical"
                             android:text="@string/match_edit_choose_team"
                             android:textColor="#B3FFFFFF"
-                            android:textSize="16sp" />
+                            android:textSize="16sp"
+                            android:maxLines="1"
+                            android:ellipsize="end"
+                            android:singleLine="true" />
 
                         <ImageView
                             android:id="@+id/ivCategoryArrow"
@@ -181,14 +184,17 @@
                             android:paddingStart="16dp"
                             android:paddingEnd="16dp">
 
-                            <TextView
-                                android:id="@+id/tvTeam2"
-                                android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:gravity="center_vertical"
-                                android:text="@string/match_edit_choose_team"
-                                android:textColor="#B3FFFFFF"
-                                android:textSize="16sp" />
+                        <TextView
+                            android:id="@+id/tvTeam2"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:gravity="center_vertical"
+                            android:text="@string/match_edit_choose_team"
+                            android:textColor="#B3FFFFFF"
+                            android:textSize="16sp"
+                            android:maxLines="1"
+                            android:ellipsize="end"
+                            android:singleLine="true" />
 
                             <ImageView
                                 android:id="@+id/ivTeamAwayArrow"

--- a/app/src/main/res/layout/fragment_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_teams_detail.xml
@@ -65,14 +65,17 @@
 
             <TextView
                 android:id="@+id/tvTeamName"
-                android:layout_width="270dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="YOUNG\nTEAM"
+                android:text="YOUNGTEAM"
                 android:textSize="48sp"
                 android:textColor="#FC4F08"
                 android:textStyle="bold"
 
                 android:fontFamily="@font/unbounded"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:singleLine="true"
                 android:lineSpacingExtra="-8dp" />
 
             <LinearLayout

--- a/app/src/main/res/layout/fragment_teams_edit.xml
+++ b/app/src/main/res/layout/fragment_teams_edit.xml
@@ -130,6 +130,8 @@
                         android:paddingVertical="12dp"
                         android:gravity="center_vertical"
                         android:maxLines="1"
+                        android:ellipsize="end"
+                        android:singleLine="true"
                         android:fontFamily="@font/poppins_regular"
                         android:textSize="16sp"/>
                 </LinearLayout>
@@ -161,6 +163,8 @@
                         android:paddingVertical="12dp"
                         android:gravity="center_vertical"
                         android:maxLines="1"
+                        android:ellipsize="end"
+                        android:singleLine="true"
                         android:fontFamily="@font/poppins_regular"
                         android:textSize="16sp"/>
                 </LinearLayout>
@@ -197,6 +201,7 @@
                         android:maxLength="4"
                         android:maxLines="1"
                         android:gravity="center_vertical"
+                        android:ellipsize="end"
                         android:singleLine="true"/>
                 </LinearLayout>
 
@@ -291,6 +296,8 @@
                     android:paddingVertical="12dp"
                     android:gravity="center_vertical"
                     android:maxLines="1"
+                    android:ellipsize="end"
+                    android:singleLine="true"
                     android:fontFamily="@font/poppins_regular"
                     android:textSize="16sp"/>
             </LinearLayout>

--- a/app/src/main/res/layout/teams_item.xml
+++ b/app/src/main/res/layout/teams_item.xml
@@ -34,6 +34,9 @@
         android:textSize="18sp"
         android:textFontWeight="700"
         android:textStyle="bold"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:singleLine="true"
         app:layout_constraintEnd_toStartOf="@id/btnNext"
         app:layout_constraintStart_toEndOf="@id/imgTeamLogo"
         app:layout_constraintTop_toTopOf="@id/imgTeamLogo" />
@@ -48,6 +51,9 @@
         android:text="New York •"
         android:textColor="#B3FFFFFF"
         android:textSize="14sp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:singleLine="true"
         app:layout_constraintStart_toStartOf="@id/tvTeamTitle"
         app:layout_constraintTop_toBottomOf="@id/tvTeamTitle" />
 
@@ -60,6 +66,9 @@
         android:text=" 23 Players"
         android:textColor="#B3FFFFFF"
         android:textSize="14sp"
+        android:maxLines="1"
+        android:ellipsize="end"
+        android:singleLine="true"
         app:layout_constraintStart_toEndOf="@+id/tvTeamCity"
         app:layout_constraintTop_toBottomOf="@+id/tvTeamTitle" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="fill_all_fields">Fill all fields to save team data.</string>
     <string name="select_position">Select position</string>
     <string name="team_edit_founded_year_limit_warning">Founded year can contain at most 4 digits.</string>
+    <string name="team_edit_player_number_limit_warning">Player number can contain at most 2 digits.</string>
 
     <string name="match_edit_choose_team">Choose team</string>
     <string name="match_edit_select_date">Select date</string>


### PR DESCRIPTION
## Summary
- show a toast when the player number limit is hit in the add player dialog and share limit constants
- force team-related input and display fields to stay on a single line with end ellipses where needed
- add a dedicated warning string for the jersey number limit toast

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcc7c3ca0832a9278c3f9d75b52c0