### PR TITLE
Switch rounded images to ShapeableImageView with shared style

### DIFF
--- a/app/src/main/res/layout/dialog_add_player.xml
+++ b/app/src/main/res/layout/dialog_add_player.xml
@@ -28,15 +28,15 @@
                 android:layout_gravity="bottom"
                 android:background="@drawable/bg_avatar_circle">
 
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:id="@+id/ivAddPhoto"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:background="@drawable/rounded_circle"
-                    android:clipToOutline="true"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/ic_plus"/>
+                    android:src="@drawable/ic_plus"
+                    app:shapeAppearanceOverlay="@style/circle"/>
 
             </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_articles.xml
+++ b/app/src/main/res/layout/fragment_articles.xml
@@ -66,7 +66,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/one"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -106,7 +106,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/two"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -145,7 +145,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/three"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -184,7 +184,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/four"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -223,7 +223,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/five"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -262,7 +262,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/six"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -301,7 +301,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/seven"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -340,7 +340,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/eight"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -379,7 +379,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/nine"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -418,7 +418,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/ten"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -457,7 +457,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/eleven"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"
@@ -496,7 +496,7 @@
                     android:layout_height="96dp"
                     android:scaleType="centerCrop"
                     android:src="@drawable/twelve"
-                    app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+                    app:shapeAppearanceOverlay="@style/imageRounded"/>
 
                 <TextView
                     android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_inventory_detail.xml
+++ b/app/src/main/res/layout/fragment_inventory_detail.xml
@@ -18,7 +18,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+        app:shapeAppearanceOverlay="@style/imageRounded"/>
 
     <ImageView
         android:id="@+id/btnBack"

--- a/app/src/main/res/layout/fragment_inventory_edit.xml
+++ b/app/src/main/res/layout/fragment_inventory_edit.xml
@@ -21,7 +21,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+        app:shapeAppearanceOverlay="@style/imageRounded"/>
     <ImageView
         android:id="@+id/btnBack"
         android:layout_width="40dp"

--- a/app/src/main/res/layout/fragment_match_detail.xml
+++ b/app/src/main/res/layout/fragment_match_detail.xml
@@ -150,17 +150,17 @@
                     android:layout_marginTop="20dp">
 
                     <!-- Левая команда -->
-                    <ImageView
+                    <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/team1Logo"
                         android:layout_width="60dp"
                         android:layout_height="60dp"
                         android:layout_marginEnd="16dp"
                         android:src="@drawable/ic_launcher_background"
-                    android:background="@drawable/rounded_bg_white"
-                    android:clipToOutline="true"
-                    android:scaleType="centerCrop"
-                    android:layout_gravity="start"
-                    android:contentDescription="FC Barcelona Logo"/>
+                        android:background="@drawable/rounded_bg_white"
+                        android:scaleType="centerCrop"
+                        android:layout_gravity="start"
+                        android:contentDescription="FC Barcelona Logo"
+                        app:shapeAppearanceOverlay="@style/imageRounded"/>
 
 
                     <LinearLayout
@@ -214,17 +214,17 @@
 
 
                     <!-- Правая команда -->
-                    <ImageView
+                    <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/team2Logo"
                         android:layout_width="60dp"
                         android:layout_height="60dp"
                         android:layout_marginEnd="16dp"
                         android:src="@drawable/ic_launcher_background"
                         android:background="@drawable/rounded_bg_white"
-                        android:clipToOutline="true"
                         android:scaleType="centerCrop"
                         android:layout_gravity="end"
-                        android:contentDescription="FC Barcelona Logo"/>
+                        android:contentDescription="FC Barcelona Logo"
+                        app:shapeAppearanceOverlay="@style/imageRounded"/>
                 </FrameLayout>
 
 

--- a/app/src/main/res/layout/fragment_match_edit.xml
+++ b/app/src/main/res/layout/fragment_match_edit.xml
@@ -79,15 +79,15 @@
                         android:layout_marginEnd="10dp"
                         android:background="@drawable/bg_avatar_circle">
 
-                        <ImageView
+                        <com.google.android.material.imageview.ShapeableImageView
                             android:id="@+id/ivAddPhoto"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:background="@drawable/rounded_circle"
-                            android:clipToOutline="true"
                             android:scaleType="centerCrop"
-                            android:src="@drawable/ic_plus"/>
+                            android:src="@drawable/ic_plus"
+                            app:shapeAppearanceOverlay="@style/circle"/>
 
                     </FrameLayout>
 
@@ -151,15 +151,15 @@
                         android:layout_marginEnd="10dp"
                         android:background="@drawable/bg_avatar_circle">
 
-                        <ImageView
+                        <com.google.android.material.imageview.ShapeableImageView
                             android:id="@+id/ivAddPhotoAwayt"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:background="@drawable/rounded_circle"
-                            android:clipToOutline="true"
                             android:scaleType="centerCrop"
-                            android:src="@drawable/ic_plus"/>
+                            android:src="@drawable/ic_plus"
+                            app:shapeAppearanceOverlay="@style/circle"/>
                     </FrameLayout>
 
                     <LinearLayout

--- a/app/src/main/res/layout/fragment_teams_detail.xml
+++ b/app/src/main/res/layout/fragment_teams_detail.xml
@@ -19,7 +19,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/RoundedImage18" />
+        app:shapeAppearanceOverlay="@style/imageRounded" />
 
     <ImageView
         android:id="@+id/btnBack"

--- a/app/src/main/res/layout/fragment_teams_edit.xml
+++ b/app/src/main/res/layout/fragment_teams_edit.xml
@@ -18,7 +18,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/RoundedImage18"/>
+        app:shapeAppearanceOverlay="@style/imageRounded"/>
 
 
     <ImageView

--- a/app/src/main/res/layout/inventory_item.xml
+++ b/app/src/main/res/layout/inventory_item.xml
@@ -7,14 +7,14 @@
     android:padding="12dp">
 
     <!-- Item Icon -->
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/imgItemIcon"
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:scaleType="centerCrop"
         android:src="@drawable/ball"
         android:background="@drawable/bg_circle"
-        android:clipToOutline="true"
+        app:shapeAppearanceOverlay="@style/imageRounded"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>

--- a/app/src/main/res/layout/item_inventory.xml
+++ b/app/src/main/res/layout/item_inventory.xml
@@ -6,14 +6,14 @@
     android:background="@drawable/bg_team_item"
     android:padding="12dp">
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/ivIcon"
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:src="@drawable/ball"
         android:background="@drawable/bg_circle"
         android:scaleType="centerCrop"
-        android:clipToOutline="true"
+        app:shapeAppearanceOverlay="@style/imageRounded"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>

--- a/app/src/main/res/layout/match_item.xml
+++ b/app/src/main/res/layout/match_item.xml
@@ -62,14 +62,15 @@
                 android:layout_height="30dp"
                 android:background="@drawable/bg_white_circle">
 
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:id="@+id/imgTeamLogo"
                     android:layout_width="24dp"
                     android:layout_height="30dp"
 
                     android:layout_gravity="center"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/vdgdsgfds" />
+                    android:src="@drawable/vdgdsgfds"
+                    app:shapeAppearanceOverlay="@style/circle" />
             </FrameLayout>
 
             <TextView
@@ -113,14 +114,15 @@
                 android:layout_height="30dp"
                 android:background="@drawable/bg_white_circle">
 
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:id="@+id/imgTeamLogo2"
                     android:layout_width="24dp"
                     android:layout_height="24dp"
 
                     android:layout_gravity="center"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/jkljfsjfls" />
+                    android:src="@drawable/jkljfsjfls"
+                    app:shapeAppearanceOverlay="@style/circle" />
             </FrameLayout>
 
             <TextView

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,12 +8,6 @@
 
     <!-- values/styles.xml -->
 
-
-    <style name="RoundedImage18" parent="">
-        <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">30dp</item>
-    </style>
-
     <style name="imageRounded" parent="">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">18dp</item>


### PR DESCRIPTION
## Summary
- replace rounded ImageView usage across match, inventory, and dialog layouts with ShapeableImageView
- apply the shared imageRounded or circle overlays so each rounded asset inherits consistent corner styling
- clean up the obsolete RoundedImage18 style now that the new overlay is used everywhere

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf44e29a0832aa4be1f7be83a8dc0