### PR TITLE
Ensure onboarding is removed after navigating to home

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/onboarding/OnboardingFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
 import com.besosn.app.utils.Constants
@@ -17,7 +18,10 @@ class OnboardingFragment : Fragment(R.layout.fragment_onboarding) {
         view.findViewById<Button>(R.id.btnStart).setOnClickListener {
             val prefs = requireContext().getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE)
             prefs.edit().putBoolean(Constants.PREF_HAS_SEEN_ONBOARDING, true).apply()
-            findNavController().navigate(R.id.action_onboardingFragment_to_homeFragment)
+            val navOptions = NavOptions.Builder()
+                .setPopUpTo(R.id.onboardingFragment, true)
+                .build()
+            findNavController().navigate(R.id.action_onboardingFragment_to_homeFragment, null, navOptions)
         }
     }
 }


### PR DESCRIPTION
## Summary
- mark onboarding as seen before navigation
- add NavOptions to pop the onboarding fragment when moving to home

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc07c55920832abbcee760d54260e5