### PR TITLE
Prevent editing and deleting teams when only two remain

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="match_detail_no_notes">No additional notes for this match.</string>
     <string name="match_detail_date_time">%1$s at %2$s</string>
 
+    <string name="teams_minimum_edit_delete_warning">You can’t edit or delete teams when only two teams remain.</string>
+
     <string name="settings_share_text">Look at wonderful app for soccer team and inventory management: http://play.google.com/store/apps/details?id=%1$s</string>
     <string name="settings_share_chooser_title">Share the app via</string>
     <string name="settings_share_error">No application available to share content.</string>


### PR DESCRIPTION
## Summary
- prevent navigating to the team editor or deletion dialog when only two teams exist
- show a toast explaining that editing or deleting is unavailable with only two teams
- add a dedicated string resource for the warning message

## Testing
- ./gradlew test *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc176475e8832abc594bb9a00f73c8