### PR TITLE
Fix home dashboard match count to include saved matches

### DIFF
--- a/app/src/main/java/com/besosn/app/data/local/db/dao/MatchDao.kt
+++ b/app/src/main/java/com/besosn/app/data/local/db/dao/MatchDao.kt
@@ -18,6 +18,9 @@ interface MatchDao {
     @Delete
     suspend fun deleteMatch(match: MatchEntity)
 
+    @Query("SELECT COUNT(*) FROM matches")
+    suspend fun countMatches(): Int
+
     @Query("DELETE FROM matches")
     suspend fun deleteAllMatches()
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/home/HomeFragment.kt
@@ -68,7 +68,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         statsJob?.cancel()
         statsJob = viewLifecycleOwner.lifecycleScope.launch {
             val matchesDeferred = async(Dispatchers.IO) {
-                MatchesLocalDataSource.loadMatches(ctx).size
+                MatchesLocalDataSource.countMatches(ctx)
             }
             val teamsDeferred = async(Dispatchers.IO) {
                 TeamsLocalDataSource.countTeams(ctx)

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
@@ -3,11 +3,14 @@ package com.besosn.app.presentation.ui.matches
 import android.content.Context
 import androidx.annotation.DrawableRes
 import com.besosn.app.R
+import com.besosn.app.data.local.db.DatabaseProvider
 import org.json.JSONArray
 import org.json.JSONException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Provides access to match data that is stored locally in SharedPreferences
@@ -20,6 +23,16 @@ object MatchesLocalDataSource {
         matches += getDefaultMatches()
         matches += loadSavedMatches(context)
         return matches
+    }
+
+    suspend fun countMatches(context: Context): Int = withContext(Dispatchers.IO) {
+        val defaultMatches = getDefaultMatches().size
+        val savedMatches = loadSavedMatches(context).size
+        val storedMatches = runCatching {
+            DatabaseProvider.get(context).matchDao().countMatches()
+        }.getOrDefault(0)
+
+        defaultMatches + savedMatches + storedMatches
     }
 
     internal fun loadSavedMatches(context: Context): List<MatchModel> {


### PR DESCRIPTION
## Summary
- add a Room DAO count query and local data source helper so match totals include database entries
- update the home dashboard to use the new counter, keeping legacy shared preferences matches in the total

## Testing
- ./gradlew test *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1ec59afc832abd50e9c13a898cef