### PR TITLE
Add inventory detail navigation from list

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryAdapter.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryAdapter.kt
@@ -11,8 +11,9 @@ import com.besosn.app.domain.model.InventoryItem
 
 class InventoryAdapter(
     private val items: MutableList<InventoryItem>,
+    private val onItemClick: (InventoryItem) -> Unit,
     private val onEdit: (InventoryItem) -> Unit,
-    private val onDelete: (InventoryItem) -> Unit
+    private val onDelete: (InventoryItem) -> Unit,
 ) : RecyclerView.Adapter<InventoryAdapter.InventoryViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InventoryViewHolder {
@@ -47,6 +48,7 @@ class InventoryAdapter(
                 }
             }
 
+            binding.root.setOnClickListener { onItemClick(item) }
             binding.btnNext.setOnClickListener { onEdit(item) }
 
 //            binding.btnDelete.setOnClickListener { onDelete(item) }

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.besosn.app.presentation.ui.inventory
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.addCallback
@@ -7,18 +8,45 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
 import com.besosn.app.databinding.FragmentInventoryDetailBinding
+import com.besosn.app.domain.model.InventoryItem
 
 class InventoryDetailFragment : Fragment(R.layout.fragment_inventory_detail) {
     private var _binding: FragmentInventoryDetailBinding? = null
     private val binding get() = _binding!!
+    private var currentItem: InventoryItem? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentInventoryDetailBinding.bind(view)
 
+        currentItem = arguments?.getSerializable("item") as? InventoryItem
+        currentItem?.let { item ->
+            binding.tvItemName.text = item.name
+            binding.tvCityValue.text = item.category
+            binding.tvFoundedValue.text = item.quantity.toString()
+            binding.tvPlayersValue.text = item.badge
+            binding.tvAboutTitle.text = getString(R.string.inventory_detail_about_title, item.name)
+            binding.tvNotes.text = item.notes.ifBlank { getString(R.string.inventory_detail_no_notes) }
+
+            val parsedUri = item.photoUri
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+            if (parsedUri != null) {
+                binding.imageView2.setImageURI(parsedUri)
+            } else {
+                binding.imageView2.setImageResource(R.drawable.ball)
+            }
+        }
+
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
-            findNavController().navigate(R.id.action_inventoryDetailFragment_to_inventoryEditFragment)
+            val bundle = Bundle().apply {
+                currentItem?.let { putSerializable("item", it) }
+            }
+            findNavController().navigate(
+                R.id.action_inventoryDetailFragment_to_inventoryEditFragment,
+                bundle,
+            )
         }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryFragment.kt
@@ -28,7 +28,7 @@ class InventoryFragment : Fragment(R.layout.fragment_inventory) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentInventoryBinding.bind(view)
 
-        adapter = InventoryAdapter(mutableListOf(), ::onEditItem, ::onDeleteItem)
+        adapter = InventoryAdapter(mutableListOf(), ::onItemClick, ::onEditItem, ::onDeleteItem)
         binding.rvInventory.layoutManager = LinearLayoutManager(requireContext())
         binding.rvInventory.adapter = adapter
 
@@ -47,6 +47,14 @@ class InventoryFragment : Fragment(R.layout.fragment_inventory) {
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
         }
+    }
+
+    private fun onItemClick(item: InventoryItem) {
+        val bundle = Bundle().apply { putSerializable("item", item) }
+        findNavController().navigate(
+            R.id.action_inventoryFragment_to_inventoryDetailFragment,
+            bundle,
+        )
     }
 
     private fun onEditItem(item: InventoryItem) {

--- a/app/src/main/res/layout/fragment_inventory_detail.xml
+++ b/app/src/main/res/layout/fragment_inventory_detail.xml
@@ -102,9 +102,10 @@
                 android:paddingTop="100dp">
 
                 <TextView
+                    android:id="@+id/tvItemName"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="BALL"
+                    android:text="@string/inventory_detail_item_name_placeholder"
                     android:textSize="48sp"
                     android:textColor="#FC4F08"
                     android:textStyle="bold"
@@ -131,7 +132,7 @@
                             android:id="@+id/tvCityValue"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Barcelona"
+                            android:text="-"
                             android:textColor="#FEA613"
                             android:textSize="20sp"
                             android:textFontWeight="700"
@@ -144,7 +145,7 @@
                             android:id="@+id/tvCityLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="City"
+                            android:text="@string/inventory_detail_category_label"
                             android:textColor="#CCFFFFFF"
                             android:textSize="18sp"
                             android:fontFamily="@font/prompt_regular"/>
@@ -162,7 +163,7 @@
                             android:id="@+id/tvFoundedValue"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="1908"
+                            android:text="0"
                             android:textColor="#FEA613"
                             android:textSize="20sp"
                             android:textStyle="bold"
@@ -172,7 +173,7 @@
                             android:id="@+id/tvFoundedLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Founded"
+                            android:text="@string/inventory_detail_quantity_label"
                             android:textColor="#CCFFFFFF"
                             android:textSize="18sp"
                             android:fontFamily="@font/prompt_regular"/>
@@ -190,7 +191,7 @@
                             android:id="@+id/tvPlayersValue"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="23"
+                            android:text="-"
                             android:textColor="#FEA613"
                             android:textSize="20sp"
                             android:textStyle="bold"
@@ -200,7 +201,7 @@
                             android:id="@+id/tvPlayersLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Players"
+                            android:text="@string/inventory_detail_status_label"
                             android:textColor="#CCFFFFFF"
                             android:textSize="18sp"
                             android:fontFamily="@font/prompt_regular"/>
@@ -216,9 +217,10 @@
                     android:layout_marginTop="10dp"/>
 
                 <TextView
+                    android:id="@+id/tvAboutTitle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="About ball"
+                    android:text="@string/inventory_detail_about_default"
                     android:textColor="#FC4F08"
                     android:layout_marginTop="10dp"
                     android:fontFamily="@font/unbounded"
@@ -227,12 +229,13 @@
                     android:textAllCaps="true"/>
 
                 <TextView
+                    android:id="@+id/tvNotes"
                     android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/inventory_detail_no_notes"
                     android:textSize="16sp"
                     android:fontFamily="@font/poppins_regular"
-                    android:textColor="#A2FFFFFF"
-                    android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-                    android:layout_height="wrap_content"/>
+                    android:textColor="#A2FFFFFF"/>
             </LinearLayout>
 
         </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,12 @@
 
     </plurals>
 
+    <string name="inventory_detail_item_name_placeholder">Item</string>
+    <string name="inventory_detail_category_label">Category</string>
+    <string name="inventory_detail_quantity_label">Quantity</string>
+    <string name="inventory_detail_status_label">Status</string>
+    <string name="inventory_detail_about_title">About %1$s</string>
+    <string name="inventory_detail_about_default">About item</string>
+    <string name="inventory_detail_no_notes">No notes provided.</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- open inventory item details when tapping a row by adding a click listener to the adapter and fragment
- populate the inventory detail screen with the selected item's data and forward it to the edit screen
- refresh the detail layout and strings so labels and placeholders match the new dynamic content

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc2113edb0832a9b38e881e59d14d5