### PR TITLE
Show toast when editing default matches

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchDetailFragment.kt
@@ -3,6 +3,7 @@ package com.besosn.app.presentation.ui.matches
 import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -37,13 +38,20 @@ class MatchDetailFragment : Fragment(R.layout.fragment_match_detail) {
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
-            match?.let {
-                val args = bundleOf(MatchEditFragment.ARG_MATCH_TO_EDIT to it)
-                findNavController().navigate(
-                    R.id.action_matchDetailFragment_to_matchEditFragment,
-                    args,
-                )
+            val matchToEdit = match ?: return@setOnClickListener
+            if (matchToEdit.isImmutable) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.match_default_edit_toast,
+                    Toast.LENGTH_SHORT,
+                ).show()
+                return@setOnClickListener
             }
+            val args = bundleOf(MatchEditFragment.ARG_MATCH_TO_EDIT to matchToEdit)
+            findNavController().navigate(
+                R.id.action_matchDetailFragment_to_matchEditFragment,
+                args,
+            )
         }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
@@ -19,6 +19,7 @@ data class MatchModel(
     val awayScore: Int? = null,
     val city: String? = null,
     val notes: String? = null,
+    val isImmutable: Boolean = false,
 ) : Serializable {
     val isFinished: Boolean get() = homeScore != null && awayScore != null
 }

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
@@ -90,6 +90,7 @@ object MatchesLocalDataSource {
                 date = past.timeInMillis,
                 homeScore = 1,
                 awayScore = 2,
+                isImmutable = true,
             ),
             MatchModel(
                 id = 2,
@@ -98,6 +99,7 @@ object MatchesLocalDataSource {
                 homeIconRes = R.drawable.vdgdsgfds,
                 awayIconRes = R.drawable.jkljfsjfls,
                 date = future.timeInMillis,
+                isImmutable = true,
             ),
         )
     }

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsDetailFragment.kt
@@ -38,6 +38,10 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnEdit.setOnClickListener {
             val currentTeam = team ?: return@setOnClickListener
+            if (currentTeam.isDefault) {
+                showImmutableTeamTooltip()
+                return@setOnClickListener
+            }
             viewLifecycleOwner.lifecycleScope.launch {
                 if (shouldBlockTeamModification()) {
                     showMinimumTeamsToast()
@@ -89,15 +93,10 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         binding.rvPlayers.adapter = PlayersAdapter(team.players)
 
 
-        if (team.isDefault) {
-            binding.btnEdit.isEnabled = false
-            binding.btnDelete.isEnabled = false
-            binding.btnDelete.visibility = View.GONE
-        } else {
-            binding.btnEdit.isEnabled = true
-            binding.btnDelete.isEnabled = true
-            binding.btnDelete.visibility = View.VISIBLE
-        }
+        binding.btnEdit.isEnabled = true
+        binding.btnEdit.alpha = if (team.isDefault) 0.6f else 1f
+        binding.btnDelete.isEnabled = !team.isDefault
+        binding.btnDelete.visibility = if (team.isDefault) View.GONE else View.VISIBLE
     }
 
     private suspend fun shouldBlockTeamModification(): Boolean {
@@ -109,6 +108,14 @@ class TeamsDetailFragment : Fragment(R.layout.fragment_teams_detail) {
         Toast.makeText(
             requireContext(),
             R.string.teams_minimum_edit_delete_warning,
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    private fun showImmutableTeamTooltip() {
+        Toast.makeText(
+            requireContext(),
+            R.string.teams_default_edit_tooltip,
             Toast.LENGTH_SHORT
         ).show()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,8 +23,10 @@
     <string name="match_detail_unknown_city">Unknown city</string>
     <string name="match_detail_no_notes">No additional notes for this match.</string>
     <string name="match_detail_date_time">%1$s at %2$s</string>
+    <string name="match_default_edit_toast">Default matches are immutable and cannot be edited.</string>
 
     <string name="teams_minimum_edit_delete_warning">You can’t edit or delete teams when only two teams remain.</string>
+    <string name="teams_default_edit_tooltip">Default teams are immutable and cannot be edited.</string>
 
     <string name="settings_share_text">Look at wonderful app for soccer team and inventory management: http://play.google.com/store/apps/details?id=%1$s</string>
     <string name="settings_share_chooser_title">Share the app via</string>


### PR DESCRIPTION
## Summary
- mark seeded default matches as immutable through the UI model
- block navigation when attempting to edit immutable matches and show a toast with a helpful explanation
- add a localized string for the immutable match toast message

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc261cc0ec832aaf4ee63c8f876d37