### PR TITLE
Fix match editing to update existing entries

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchModel.kt
@@ -24,3 +24,4 @@ data class MatchModel(
 }
 
 internal const val DB_MATCH_ID_OFFSET = 10_000
+internal const val LEGACY_MATCH_ID_OFFSET = 1_000

--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.activity.addCallback
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -41,6 +42,16 @@ class MatchesFragment : Fragment(R.layout.fragment_matches) {
         setupFilters()
         loadMatches()
         observeSavedMatches()
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<Boolean>(MatchEditFragment.RESULT_KEY_MATCHES_UPDATED)
+            ?.observe(viewLifecycleOwner, Observer { shouldReload ->
+                if (shouldReload == true) {
+                    loadMatches()
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.remove<Boolean>(MatchEditFragment.RESULT_KEY_MATCHES_UPDATED)
+                }
+            })
 
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.btnAdd.setOnClickListener {


### PR DESCRIPTION
## Summary
- update the match editor to detect legacy saved matches, rewrite them in place, and signal the list to refresh so edits do not create duplicates
- enrich the local matches data source with URI/city/note support and expose the legacy ID offset used by the editor
- listen for edit results in the matches screen so the UI reloads after an edit

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc28f73b28832a96dcaf38fca3ef8b