### PR TITLE
Remove splash from back stack when navigating to onboarding

### DIFF
--- a/app/src/main/res/navigation/navgraph.xml
+++ b/app/src/main/res/navigation/navgraph.xml
@@ -10,7 +10,9 @@
         android:label="SplashFragment">
         <action
             android:id="@+id/action_splashFragment_to_onboardingFragment"
-            app:destination="@id/onboardingFragment" />
+            app:destination="@id/onboardingFragment"
+            app:popUpTo="@id/splashFragment"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_splashFragment_to_homeFragment"
             app:destination="@id/homeFragment" />


### PR DESCRIPTION
## Summary
- ensure the navigation action from the splash screen pops the splash fragment from the back stack when opening onboarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc4b0a2efc832ab659c0a283c74022