### PR TITLE
Add feedback and deletion handling for match details

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/matches/MatchesLocalDataSource.kt
@@ -131,6 +131,34 @@ object MatchesLocalDataSource {
         }
     }
 
+    internal fun deleteSavedMatch(context: Context, index: Int): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getString(PREFS_KEY_MATCHES, null) ?: return false
+
+        return try {
+            val array = JSONArray(raw)
+            if (index < 0 || index >= array.length()) return false
+
+            val updated = JSONArray()
+            for (i in 0 until array.length()) {
+                if (i == index) continue
+                val obj = array.optJSONObject(i) ?: continue
+                updated.put(obj)
+            }
+
+            val editor = prefs.edit()
+            if (updated.length() == 0) {
+                editor.remove(PREFS_KEY_MATCHES)
+            } else {
+                editor.putString(PREFS_KEY_MATCHES, updated.toString())
+            }
+            editor.apply()
+            true
+        } catch (_: JSONException) {
+            false
+        }
+    }
+
     private fun getDefaultMatches(): List<MatchModel> {
         val now = Calendar.getInstance()
         val past = (now.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -1) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="match_detail_no_notes">No additional notes for this match.</string>
     <string name="match_detail_date_time">%1$s at %2$s</string>
     <string name="match_default_edit_toast">Default matches are immutable and cannot be edited.</string>
+    <string name="match_default_delete_toast">Default matches cannot be deleted.</string>
+    <string name="match_delete_success">Match deleted.</string>
+    <string name="match_delete_failed">Failed to delete match. Please try again.</string>
 
     <string name="teams_minimum_edit_delete_warning">You can’t edit or delete teams when only two teams remain.</string>
     <string name="teams_default_edit_tooltip">Default teams are immutable and cannot be edited.</string>


### PR DESCRIPTION
## Summary
- add deletion handling on the match detail screen, including feedback when immutable matches are tapped
- dim edit/delete buttons for immutable matches and provide success/failure messaging for deletions
- expose a shared-preferences deletion helper and supporting string resources

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc503f7f6c832a8e89ed89d3f80342