### PR TITLE
Restore default teams after clearing app data

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import androidx.room.Room
 import com.besosn.app.R
 import com.besosn.app.data.local.db.AppDatabase
 import com.besosn.app.databinding.FragmentSettingsBinding
+import com.besosn.app.presentation.ui.teams.TeamsLocalDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -95,7 +96,7 @@ class SettingsFragment : Fragment(R.layout.fragment_settings) {
         viewLifecycleOwner.lifecycleScope.launch {
             val context = requireContext().applicationContext
             val success = withContext(Dispatchers.IO) {
-                runCatching {
+                try {
                     val db = Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
                         .fallbackToDestructiveMigration()
                         .build()
@@ -113,7 +114,12 @@ class SettingsFragment : Fragment(R.layout.fragment_settings) {
                         .edit()
                         .remove(PREFS_KEY_MATCHES)
                         .apply()
-                }.isSuccess
+
+                    TeamsLocalDataSource.seedDefaultTeamsIfNeeded(context)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
             }
 
             if (!isAdded) return@launch

--- a/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsLocalDataSource.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/teams/TeamsLocalDataSource.kt
@@ -40,6 +40,10 @@ object TeamsLocalDataSource {
         db.teamDao().getTeams().size
     }
 
+    suspend fun seedDefaultTeamsIfNeeded(context: Context) = withContext(Dispatchers.IO) {
+        ensureDefaultTeams(DatabaseProvider.get(context))
+    }
+
     private suspend fun ensureDefaultTeams(db: AppDatabase) {
         seedMutex.withLock {
             val teamDao = db.teamDao()


### PR DESCRIPTION
## Summary
- ensure clearing data from Settings also repopulates the default demo teams and their players
- expose a reusable helper to seed default teams when the database is empty

## Testing
- ./gradlew lint *(fails locally: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc504dbef4832abe53ba8d1489d02d