### PR TITLE
Fix inventory deletion navigation

### DIFF
--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryDetailFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryDetailFragment.kt
@@ -1,19 +1,30 @@
 package com.besosn.app.presentation.ui.inventory
 
+import android.app.Dialog
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.besosn.app.R
+import com.besosn.app.databinding.DialogInventoryConfirmDeleteBinding
 import com.besosn.app.databinding.FragmentInventoryDetailBinding
 import com.besosn.app.domain.model.InventoryItem
+import com.besosn.app.presentation.viewmodel.InventoryViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class InventoryDetailFragment : Fragment(R.layout.fragment_inventory_detail) {
     private var _binding: FragmentInventoryDetailBinding? = null
     private val binding get() = _binding!!
     private var currentItem: InventoryItem? = null
+    private val viewModel: InventoryViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -48,8 +59,46 @@ class InventoryDetailFragment : Fragment(R.layout.fragment_inventory_detail) {
                 bundle,
             )
         }
+        binding.btnDelete.setOnClickListener {
+            currentItem?.let { showDeleteConfirmationDialog(it) }
+        }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun showDeleteConfirmationDialog(item: InventoryItem) {
+        val dialogBinding = DialogInventoryConfirmDeleteBinding.inflate(layoutInflater)
+        val dialog = Dialog(requireContext()).apply {
+            setContentView(dialogBinding.root)
+            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        }
+
+        val deleteAction = {
+            viewModel.deleteItem(item)
+            dialog.dismiss()
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.inventory_delete_success),
+                Toast.LENGTH_SHORT,
+            ).show()
+            navigateBackToInventory()
+        }
+
+        dialogBinding.btnConfirm.setOnClickListener { deleteAction() }
+        dialogBinding.btnDelete.setOnClickListener { deleteAction() }
+
+        dialog.show()
+        dialog.window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+    }
+
+    private fun navigateBackToInventory() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.inventoryFragment, false)) {
+            navController.navigate(R.id.inventoryFragment)
         }
     }
 

--- a/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryEditFragment.kt
+++ b/app/src/main/java/com/besosn/app/presentation/ui/inventory/InventoryEditFragment.kt
@@ -162,7 +162,12 @@ class InventoryEditFragment : Fragment() {
         val deleteAction = {
             viewModel.deleteItem(item)
             dialog.dismiss()
-            findNavController().popBackStack()
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.inventory_delete_success),
+                Toast.LENGTH_SHORT,
+            ).show()
+            navigateToInventoryScreen()
         }
 
         dialogBinding.btnConfirm.setOnClickListener { deleteAction() }
@@ -170,6 +175,13 @@ class InventoryEditFragment : Fragment() {
 
         dialog.show()
         dialog.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    private fun navigateToInventoryScreen() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.inventoryFragment, false)) {
+            navController.navigate(R.id.inventoryFragment)
+        }
     }
 
     private fun setupDropdown(anchorView: FrameLayout, tv: TextView, arrow: View, list: List<String>) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,5 +72,6 @@
     <string name="inventory_detail_about_title">About %1$s</string>
     <string name="inventory_detail_about_default">About item</string>
     <string name="inventory_detail_no_notes">No notes provided.</string>
+    <string name="inventory_delete_success">Inventory item deleted.</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- add Hilt view model to the inventory detail screen and hook up the delete button with the confirm dialog
- ensure deleting an inventory item navigates back to the list from both detail and edit screens and show a success toast
- add a shared inventory delete success string resource

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5eecf148832a8cca0ffe24df0e1d